### PR TITLE
Anticipate DataException for out-of-bounds items - add warnings instead

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,11 +73,11 @@ jobs:
 
 # Remove the comment to the lines below during development, to refresh the
 # media file dumps.
-#    - name: Update media dumps
-#      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
+    - name: Update media dumps
+      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
 
-#    - name: Upload media dumps
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: media-dumps
-#        path: tests/media-dumps
+    - name: Upload media dumps
+      uses: actions/upload-artifact@v2
+      with:
+        name: media-dumps
+        path: tests/media-dumps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,11 +72,11 @@ jobs:
 
 # Remove the comment to the lines below during development, to refresh the
 # media file dumps.
-    - name: Update media dumps
-      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
+#    - name: Update media dumps
+#      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
 
-    - name: Upload media dumps
-      uses: actions/upload-artifact@v2
-      with:
-        name: media-dumps
-        path: tests/media-dumps
+#    - name: Upload media dumps
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: media-dumps
+#        path: tests/media-dumps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Run test suite
       run: vendor/bin/phpunit ./tests
-      continue-on-error: true
+#      continue-on-error: true
 
     - name: Code style test
       if: ${{ matrix.php-version == 7.4 }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Run test suite
       run: vendor/bin/phpunit ./tests
-#      continue-on-error: true
+      continue-on-error: true
 
     - name: Code style test
       if: ${{ matrix.php-version == 7.4 }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,11 +72,11 @@ jobs:
 
 # Remove the comment to the lines below during development, to refresh the
 # media file dumps.
-#    - name: Update media dumps
-#      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
+    - name: Update media dumps
+      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
 
-#    - name: Upload media dumps
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: media-dumps
-#        path: tests/media-dumps
+    - name: Upload media dumps
+      uses: actions/upload-artifact@v2
+      with:
+        name: media-dumps
+        path: tests/media-dumps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,11 +74,11 @@ jobs:
 
 # Remove the comment to the lines below during development, to refresh the
 # media file dumps.
-    - name: Update media dumps
-      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
+#    - name: Update media dumps
+#      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
 
-    - name: Upload media dumps
-      uses: actions/upload-artifact@v2
-      with:
-        name: media-dumps
-        path: tests/media-dumps
+#    - name: Upload media dumps
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: media-dumps
+#        path: tests/media-dumps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
       continue-on-error: true
       run: |
         php examples/dump-media.php -d tests/media-samples/image/broken/canon-eos-650d.jpg
+        php examples/dump-media.php -d tests/media-samples/image/broken/gh-10-b.jpg
 
     - name: Run test suite
       continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,7 @@ jobs:
         php examples/dump-media.php -d tests/media-samples/image/exiftool/Canon1DmkIII.jpg
 
     - name: Run test suite
+      continue-on-error: true
       run: vendor/bin/phpunit ./tests
 
     - name: Code style test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,8 @@ jobs:
         php examples/dump-media.php -d tests/media-samples/image/broken/gh-10-b.jpg
 
     - name: Run test suite
-      continue-on-error: true
       run: vendor/bin/phpunit ./tests
+#      continue-on-error: true
 
     - name: Code style test
       if: ${{ matrix.php-version == 7.4 }}
@@ -72,11 +72,11 @@ jobs:
 
 # Remove the comment to the lines below during development, to refresh the
 # media file dumps.
-    - name: Update media dumps
-      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
+#    - name: Update media dumps
+#      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
 
-    - name: Upload media dumps
-      uses: actions/upload-artifact@v2
-      with:
-        name: media-dumps
-        path: tests/media-dumps
+#    - name: Upload media dumps
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: media-dumps
+#        path: tests/media-dumps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Image file dumps
       continue-on-error: true
       run: |
-        php examples/dump-media.php -d tests/media-samples/image/broken/canon-eos-650d.jpg-rewrite.img
+        php examples/dump-media.php -d tests/media-samples/image/broken/canon-eos-650d.jpg
 
     - name: Run test suite
       continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,10 +59,7 @@ jobs:
     - name: Image file dumps
       continue-on-error: true
       run: |
-        php examples/dump-media.php -d tests/media-samples/image/pel-157.tiff
-        php examples/dump-media.php -d tests/media-samples/image/broken/gh-10-b.jpg
-        php examples/dump-media.php -d tests/media-samples/image/exiftool/Canon.jpg
-        php examples/dump-media.php -d tests/media-samples/image/exiftool/Canon1DmkIII.jpg
+        php examples/dump-media.php -d tests/media-samples/image/broken/canon-eos-650d.jpg-rewrite.img
 
     - name: Run test suite
       continue-on-error: true

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,3 +1,10 @@
+php examples/dump-media.php -d tests/media-samples/image/pel-157.tiff
+php examples/dump-media.php -d tests/media-samples/image/broken/gh-10-b.jpg
+php examples/dump-media.php -d tests/media-samples/image/broken/canon-eos-650d.jpg-rewrite.img
+php examples/dump-media.php -d tests/media-samples/image/exiftool/Canon.jpg
+php examples/dump-media.php -d tests/media-samples/image/exiftool/Canon1DmkIII.jpg
+
+
 - name: Image file dumps
   continue-on-error: true
   run: php examples/dump-media.php -d -w tests/media-samples/image/broken/canon-eos-650d.jpg

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -52,7 +52,7 @@ class Ifd extends ListBase
                 );
                 continue;
             }
-            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data->getSize()) {
+            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
                 $this->warning(
                     'Could not get value for item \'{item}\' in \'{ifd}\', not enough data', [
                         'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name') ?? 'n/a'),

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -52,8 +52,10 @@ class Ifd extends ListBase
                 continue;
             }
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
-                $xxxa = $data_element->getLong($i_offset);
+                $xxxa = $data_element->getLong($i_offset + 8);
+dump(MediaProbe::dumpIntHex($xxxa));
                 $xxxb = $data_element->getShort($xxxa);
+dump(MediaProbe::dumpIntHex($xxxb));
                 $this->debug(
                     'Item Offset {o} Components {c} Format {f} Formatsize {fs} Size {s} DataElement Size {des}', [
                         'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -46,7 +46,16 @@ class Ifd extends ListBase
             if ($item_definition->getDataOffset() >= $data_element->getSize()) {
                 $this->warning(
                     'Could not access value for item {item} in \'{ifd}\', overflow', [
-                        'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name')),
+                        'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name') ?? 'n/a'),
+                        'ifd' => $this->getAttribute('name'),
+                    ]
+                );
+                continue;
+            }
+            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data->getSize()) {
+                $this->warning(
+                    'Could not get value for item \'{item}\' in \'{ifd}\', not enough data', [
+                        'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name') ?? 'n/a'),
                         'ifd' => $this->getAttribute('name'),
                     ]
                 );

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -56,8 +56,8 @@ class Ifd extends ListBase
                 $this->debug(
                     'Item Offset {o} Components {c} Format {f} Formatsize {fs} Size {s} DataElement Size {des}', [
                         'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),
-                        'c' => $item_definition->getValuesCount();
-                        'f' => $item_definition->getFormat();
+                        'c' => $item_definition->getValuesCount(),
+                        'f' => $item_definition->getFormat(),
                         'fs' => DataFormat::getSize($item_definition->getFormat());
                         's' => MediaProbe::dumpIntHex($item_definition->getSize()),
                         'des' => MediaProbe::dumpIntHex($data_element->getSize()),

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -58,7 +58,7 @@ class Ifd extends ListBase
                         'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),
                         'c' => $item_definition->getValuesCount(),
                         'f' => $item_definition->getFormat(),
-                        'fs' => DataFormat::getSize($item_definition->getFormat());
+                        'fs' => DataFormat::getSize($item_definition->getFormat()),
                         's' => MediaProbe::dumpIntHex($item_definition->getSize()),
                         'des' => MediaProbe::dumpIntHex($data_element->getSize()),
                     ]

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -55,8 +55,8 @@ class Ifd extends ListBase
                 $this->debug(
                     'Item Offset {o} Size {s} DataElement Size {des}', [
                         'o' => MediaProbe::dumpIntHex($item_definition->getDataOffset()),
-                        's' => $item_definition->getSize(),
-                        'des' => $data_element->getSize(),
+                        's' => MediaProbe::dumpIntHex($item_definition->getSize()),
+                        'des' => MediaProbe::dumpIntHex($data_element->getSize()),
                     ]
                 );
                 $this->warning(

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -45,12 +45,12 @@ class Ifd extends ListBase
             // Check data is accessible, warn otherwise.
             if ($item_definition->getDataOffset() >= $data_element->getSize()) {
                 $this->warning(
-                    'Could not access value for item \'{item}\' in \'{map}\', overflow', [
-                        'item' => $item_definition->getCollection()->getPropertyValue('name'),
-                        'map' => $this->getAttribute('name'),
+                    'Could not access value for item {item} in \'{ifd}\', overflow', [
+                        'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name')),
+                        'ifd' => $this->getAttribute('name'),
                     ]
                 );
-//                continue;
+                continue;
             }
 
             // Adds the item to the DOM.

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -54,7 +54,7 @@ class Ifd extends ListBase
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
                 $this->debug(
                     'Item Offset {o} Size {s} DataElement Size {des}', [
-                        'o' => MediaProbe::dumpIntHex($item_definition->getDataOffset()),
+                        'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),
                         's' => MediaProbe::dumpIntHex($item_definition->getSize()),
                         'des' => MediaProbe::dumpIntHex($data_element->getSize()),
                     ]

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -52,10 +52,12 @@ class Ifd extends ListBase
                 continue;
             }
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
+                $xxxa = $data_element->getLong($i_offset);
+                $xxxb = $data_element->getShort($xxxa);
                 $this->debug(
                     'Item Offset {o} Components {c} Format {f} Formatsize {fs} Size {s} DataElement Size {des}', [
                         'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),
-                        'c' => $item_definition->getValuesCount(),
+                        'c' => $xxxb,
                         'f' => $item_definition->getFormat(),
                         'fs' => DataFormat::getSize($item_definition->getFormat()),
                         's' => MediaProbe::dumpIntHex($item_definition->getSize()),

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -30,7 +30,6 @@ class Ifd extends ListBase
      */
     public function parseData(DataElement $data_element, int $start = 0, ?int $size = null, $xxx = 0): void
     {
-        //$ifd_data = new DataWindow($data_element, $start, $size);
         $offset = $this->getDefinition()->getDataOffset();
 
         // Get the number of entries.
@@ -55,13 +54,13 @@ class Ifd extends ListBase
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
                 $this->debug(
                     'Item Offset {o} Size {s} DataElement Size {des}', [
-                        'o' => $item_definition->getDataOffset(),
+                        'o' => MediaProbe::dumpIntHex($item_definition->getDataOffset()),
                         's' => $item_definition->getSize(),
                         'des' => $data_element->getSize(),
                     ]
                 );
                 $this->warning(
-                    'Could not get value for item \'{item}\' in \'{ifd}\', not enough data', [
+                    'Could not get value for item {item} in \'{ifd}\', not enough data', [
                         'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name') ?? 'n/a'),
                         'ifd' => $this->getAttribute('name'),
                     ]

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -55,7 +55,7 @@ class Ifd extends ListBase
             $this->debug(
                 'Item Offset {o} Components {c} Format {f} Formatsize {fs} Size {s} DataElement Size {des}', [
                     'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),
-                    'c' => $xxxb,
+                    'c' => $item_definition->getValuesCount(),
                     'f' => $item_definition->getFormat(),
                     'fs' => DataFormat::getSize($item_definition->getFormat()),
                     's' => MediaProbe::dumpIntHex($item_definition->getSize()),

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -9,6 +9,7 @@ use FileEye\MediaProbe\Block\Thumbnail;
 use FileEye\MediaProbe\Collection;
 use FileEye\MediaProbe\Data\DataElement;
 use FileEye\MediaProbe\Data\DataException;
+use FileEye\MediaProbe\Data\DataFormat;
 use FileEye\MediaProbe\Data\DataString;
 use FileEye\MediaProbe\Data\DataWindow;
 use FileEye\MediaProbe\ElementInterface;
@@ -53,8 +54,11 @@ class Ifd extends ListBase
             }
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
                 $this->debug(
-                    'Item Offset {o} Size {s} DataElement Size {des}', [
+                    'Item Offset {o} Components {c} Format {f} Formatsize {fs} Size {s} DataElement Size {des}', [
                         'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),
+                        'c' => $item_definition->getValuesCount();
+                        'f' => $item_definition->getFormat();
+                        'fs' => DataFormat::getSize($item_definition->getFormat());
                         's' => MediaProbe::dumpIntHex($item_definition->getSize()),
                         'des' => MediaProbe::dumpIntHex($data_element->getSize()),
                     ]

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -54,6 +54,7 @@ class Ifd extends ListBase
                     $item->parseData($data_element, $item_definition->getDataOffset(), $item_data_window_size);
                 }
             } catch (DataException $e) {
+dump('xxx');
                 $item->error($e->getMessage());
                 $item->valid = false;
             }

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -16,7 +16,6 @@ use FileEye\MediaProbe\ElementInterface;
 use FileEye\MediaProbe\Entry\Core\EntryInterface;
 use FileEye\MediaProbe\Entry\Core\Undefined;
 use FileEye\MediaProbe\ItemDefinition;
-use FileEye\MediaProbe\Data\DataFormat;
 use FileEye\MediaProbe\MediaProbe;
 use FileEye\MediaProbe\MediaProbeException;
 use FileEye\MediaProbe\Utility\ConvertBytes;

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -52,15 +52,22 @@ class Ifd extends ListBase
                 );
                 continue;
             }
-/*            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
+            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
+                $this->debug(
+                    'Item Offset {o} Size {s} DataElement Size {des}', [
+                        'o' => $item_definition->getDataOffset(),
+                        's' => $item_definition->getSize(),
+                        'des' => $data_element->getSize(),
+                    ]
+                );
                 $this->warning(
                     'Could not get value for item \'{item}\' in \'{ifd}\', not enough data', [
                         'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name') ?? 'n/a'),
                         'ifd' => $this->getAttribute('name'),
                     ]
                 );
-                continue;
-            }*/
+//                continue;
+            }
 
             // Adds the item to the DOM.
             $item_class = $item_definition->getCollection()->getPropertyValue('class');

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -52,7 +52,7 @@ class Ifd extends ListBase
                 );
                 continue;
             }
-            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
+/*            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
                 $this->warning(
                     'Could not get value for item \'{item}\' in \'{ifd}\', not enough data', [
                         'item' => MediaProbe::dumpIntHex($item_definition->getCollection()->getPropertyValue('name') ?? 'n/a'),
@@ -60,7 +60,7 @@ class Ifd extends ListBase
                     ]
                 );
                 continue;
-            }
+            }*/
 
             // Adds the item to the DOM.
             $item_class = $item_definition->getCollection()->getPropertyValue('class');

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -41,6 +41,19 @@ class Ifd extends ListBase
         for ($i = 0; $i < $n; $i++) {
             $i_offset = $offset + 2 + 12 * $i;
             $item_definition = $this->getItemDefinitionFromData($i, $data_element, $i_offset, $xxx, 'Tiff\IfdAny');
+
+            // Check data is accessible, warn otherwise.
+            if ($item_definition->getDataOffset() >= $data_element->getSize()) {
+                $this->warning(
+                    'Could not access value for item \'{item}\' in \'{map}\', overflow', [
+                        'item' => $item_definition->getCollection()->getPropertyValue('name'),
+                        'map' => $this->getAttribute('name'),
+                    ]
+                );
+//                continue;
+            }
+
+            // Adds the item to the DOM.
             $item_class = $item_definition->getCollection()->getPropertyValue('class');
             $item = new $item_class($item_definition, $this);
             try {
@@ -54,7 +67,6 @@ class Ifd extends ListBase
                     $item->parseData($data_element, $item_definition->getDataOffset(), $item_data_window_size);
                 }
             } catch (DataException $e) {
-dump('xxx');
                 $item->error($e->getMessage());
                 $item->valid = false;
             }

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -52,7 +52,7 @@ class Ifd extends ListBase
                 );
                 continue;
             }
-            $this->debug(
+/*            $this->debug(
                 'Item Offset {o} Components {c} Format {f} Formatsize {fs} Size {s} DataElement Size {des}', [
                     'o' => MediaProbe::dumpIntHex($data_element->getAbsoluteOffset($item_definition->getDataOffset())),
                     'c' => $item_definition->getValuesCount(),
@@ -61,7 +61,7 @@ class Ifd extends ListBase
                     's' => MediaProbe::dumpIntHex($item_definition->getSize()),
                     'des' => MediaProbe::dumpIntHex($data_element->getSize()),
                 ]
-            );
+            );*/
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data_element->getSize()) {
                 $this->warning(
                     'Could not get value for item {item} in \'{ifd}\', not enough data', [
@@ -69,7 +69,7 @@ class Ifd extends ListBase
                         'ifd' => $this->getAttribute('name'),
                     ]
                 );
-//                continue;
+                continue;
             }
 
             // Adds the item to the DOM.

--- a/src/Block/Index.php
+++ b/src/Block/Index.php
@@ -40,7 +40,7 @@ class Index extends ListBase
             $offset = 0;
             $index_size = $this->getValueFromData($data_element, $offset, $this->getCollection()->getPropertyValue('format')[0]);
             if ($index_size !== $this->getDefinition()->getSize()) {
-                $this->warning("Size mismatch between IFD and index header");
+                $this->error("Size mismatch between IFD and index header");
             }
         }
     }

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -57,7 +57,7 @@ class Map extends Index
             // Adds a 'tag'.
             $n = $item * DataFormat::getSize($this->getFormat());
             $item_definition = $this->getItemDefinitionFromData($i, $item, $data, $n);
-            if ($item_definition->getDataOffset() > $data->getSize()) {
+            if ($item_definition->getDataOffset() >= $data->getSize()) {
                 $this->warning('Offset! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
 //                continue;
             }

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -54,9 +54,10 @@ class Map extends Index
         // Build the map items.
         $i = 0;
         foreach ($this->getCollection()->listItemIds() as $item) {
-            // Adds a 'tag'.
             $n = $item * DataFormat::getSize($this->getFormat());
             $item_definition = $this->getItemDefinitionFromData($i, $item, $data, $n);
+
+            // Check data is accessible, warn otherwise.
             if ($item_definition->getDataOffset() >= $data->getSize()) {
                 $this->warning(
                     'Could not access value for item \'{item}\' in \'{map}\', overflow', [
@@ -73,9 +74,10 @@ class Map extends Index
                         'map' => $this->getAttribute('name'),
                     ]
                 );
-                $this->warning('Size! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
                 continue;
             }
+
+            // Adds a 'tag' to the DOM.
             $block = $this->addBlock($item_definition);
             try {
                 $block->parseData($data, $item_definition->getDataOffset(), $item_definition->getSize());
@@ -83,6 +85,7 @@ class Map extends Index
                 $block->error($e->getMessage());
                 $block->valid = false;
             }
+
             $i++;
         }
     }

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -58,12 +58,19 @@ class Map extends Index
             $n = $item * DataFormat::getSize($this->getFormat());
             $item_definition = $this->getItemDefinitionFromData($i, $item, $data, $n);
             if ($item_definition->getDataOffset() >= $data->getSize()) {
+                $this->warning(
+                    'Could not access value for item \'{item}\' in \'{map}\', not enough data', [
+                        'item' => 'xxx',
+                        'map' => $this->getAttribute('name'),
+                    ]
+                );
+dump($item_definition);
                 $this->warning('Offset! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
-//                continue;
+                continue;
             }
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data->getSize()) {
                 $this->warning('Size! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
-//                continue;
+                continue;
             }
             $block = $this->addBlock($item_definition);
             try {

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -77,13 +77,13 @@ class Map extends Index
                 continue;
             }
 
-            // Adds a 'tag' to the DOM.
-            $block = $this->addBlock($item_definition);
+            // Adds the item to the DOM.
+            $item = $this->addBlock($item_definition);
             try {
-                $block->parseData($data, $item_definition->getDataOffset(), $item_definition->getSize());
+                $item->parseData($data, $item_definition->getDataOffset(), $item_definition->getSize());
             } catch (DataException $e) {
-                $block->error($e->getMessage());
-                $block->valid = false;
+                $item->error($e->getMessage());
+                $item->valid = false;
             }
 
             $i++;

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -58,11 +58,11 @@ class Map extends Index
             $n = $item * DataFormat::getSize($this->getFormat());
             $item_definition = $this->getItemDefinitionFromData($i, $item, $data, $n);
             if ($item_definition->getDataOffset() > $data->getSize()) {
-                $this->warning('Offset!');
+                $this->warning('Offset! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
 //                continue;
             }
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data->getSize()) {
-                $this->warning('Size!');
+                $this->warning('Size! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
 //                continue;
             }
             $block = $this->addBlock($item_definition);

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -57,6 +57,14 @@ class Map extends Index
             // Adds a 'tag'.
             $n = $item * DataFormat::getSize($this->getFormat());
             $item_definition = $this->getItemDefinitionFromData($i, $item, $data, $n);
+            if ($item_definition->getDataOffset() > $data->getSize()) {
+                $this->warning('Offset!');
+//                continue;
+            }
+            if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data->getSize()) {
+                $this->warning('Size!');
+//                continue;
+            }
             $block = $this->addBlock($item_definition);
             try {
                 $block->parseData($data, $item_definition->getDataOffset(), $item_definition->getSize());
@@ -94,8 +102,6 @@ class Map extends Index
             return '';
         }
         $mapDataBytes = $mapDataElement->toBytes();
-//if ($this->getAttribute('name') === 'CanonFilterInfo') dump($offset, MediaProbe::dumpHexFormatted($data_element->getBytes($offset - 1024, 10000)));
-//dump(['toBytes', $this->getAttribute('name'), MediaProbe::dumpHexFormatted($mapDataBytes)]);
 
         // Dump each tag at the position in the map specified by the item id.
         foreach ($this->getMultipleElements('*[not(self::rawData)]') as $sub_id => $sub) {

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -59,16 +59,20 @@ class Map extends Index
             $item_definition = $this->getItemDefinitionFromData($i, $item, $data, $n);
             if ($item_definition->getDataOffset() >= $data->getSize()) {
                 $this->warning(
-                    'Could not access value for item \'{item}\' in \'{map}\', not enough data', [
-                        'item' => 'xxx',
+                    'Could not access value for item \'{item}\' in \'{map}\', overflow', [
+                        'item' => $item_definition->getCollection()->getPropertyValue('name'),
                         'map' => $this->getAttribute('name'),
                     ]
                 );
-dump($item_definition);
-                $this->warning('Offset! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
                 continue;
             }
             if ($item_definition->getDataOffset() +  $item_definition->getSize() > $data->getSize()) {
+                $this->warning(
+                    'Could not get value for item \'{item}\' in \'{map}\', not enough data', [
+                        'item' => $item_definition->getCollection()->getPropertyValue('name'),
+                        'map' => $this->getAttribute('name'),
+                    ]
+                );
                 $this->warning('Size! ' . $data->getSize() . ' -> ' . $item_definition->getDataOffset() . ' ' . $item_definition->getSize());
                 continue;
             }

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -34,7 +34,8 @@ class Tag extends BlockBase
     {
         // Check if MediaProbe has a definition for this TAG.
         if (in_array($this->getCollection()->getId(), ['VoidCollection', 'UnknownTag'])) {
-            $this->notice("No specification for item {item} in '{ifd}'", [
+            $this->notice("Unknown item '{item}' in '{ifd}'", [
+dump($this->getCollection());
                 'item' => $this->getCollection()->getId(),
                 'ifd' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
             ]);

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -48,7 +48,7 @@ class Tag extends BlockBase
             foreach ($expected_format as $expected_format_id) {
                 $expected_format_names[] = DataFormat::getName($expected_format_id);
             }
-            $this->warning("Found {format_name} data format, expected {expected_format_names} for item {item} in '{parent}'", [
+            $this->warning("Found {format_name} data format, expected {expected_format_names} for item '{item}' in '{parent}'", [
                 'format_name' => DataFormat::getName($this->getFormat()),
                 'expected_format_names' => implode(', ', $expected_format_names),
                 'item' => $this->getAttribute('name') ?? 'n/a',
@@ -59,7 +59,7 @@ class Tag extends BlockBase
         // Warn if components are not as expected.
         $expected_components = $this->getCollection()->getPropertyValue('components');
         if ($expected_components !== null && $this->getComponents() !== null && $this->getComponents() !== $expected_components) {
-            $this->warning("Found {components} data components, expected {expected_components} for item {item} in '{parent}'", [
+            $this->warning("Found {components} data components, expected {expected_components} for item '{item}' in '{parent}'", [
                 'components' => $this->getComponents(),
                 'expected_components' => $expected_components,
                 'item' => $this->getAttribute('name') ?? 'n/a',

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -145,27 +145,21 @@ dump($this->getCollection());
         if ($name ==! null) {
             $msg .= ':{name}';
         }
-//$title = $this->getCollection()->getPropertyValue('title');
-//if ($title ==! null) {
-//    $msg .= ' ({title})';
-//}
         $item = $this->getAttribute('id');
         if ($item ==! null) {
             $msg .= ' ({item})';
         }
-        if (is_numeric($item)) {
-            $item = $item . '/0x' . strtoupper(dechex($item));
-        }
+        $item .= MediaProbe::dumpIntHex($item);
         if ($data_element instanceof DataWindow) {
             $msg .= ' @{offset} s {size}';
-            $offset = $data_element->getAbsoluteOffset() . '/0x' . strtoupper(dechex($data_element->getAbsoluteOffset()));
+            $offset = MediaProbe::dumpIntHex($data_element->getAbsoluteOffset());
         } else {
             $msg .= ' size {size} byte(s)';
         }
         $msg .= ', f {format}, c {components}';
         $this->debug($msg, [
             'seq' => $seq,
-            'ifdoffset' => $item_definition_offset . '/0x' . strtoupper(dechex($item_definition_offset)),
+            'ifdoffset' => MediaProbe::dumpIntHex($item_definition_offset),
             'format' => DataFormat::getName($this->getDefinition()->getFormat()),
             'components' => $this->getDefinition()->getValuesCount(),
             'node' => $node,

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -35,7 +35,7 @@ class Tag extends BlockBase
         // Check if MediaProbe has a definition for this tag.
         if (in_array($this->getCollection()->getId(), ['VoidCollection', 'UnknownTag'])) {
             $this->notice("Unknown item {item} in '{ifd}'", [
-                'item' => $this->getAttribute('id'),
+                'item' => MediaProbe::dumpIntHex($this->getAttribute('id')),
                 'ifd' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
             ]);
         } else {

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -34,32 +34,37 @@ class Tag extends BlockBase
     {
         // Check if MediaProbe has a definition for this tag.
         if (in_array($this->getCollection()->getId(), ['VoidCollection', 'UnknownTag'])) {
-            $this->notice("Unknown item {item} in '{ifd}'", [
+            $this->notice("Unknown item {item} in '{parent}'", [
                 'item' => MediaProbe::dumpIntHex($this->getAttribute('id')),
-                'ifd' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
+                'parent' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
             ]);
-        } else {
-            // Warn if format is not as expected.
-            $expected_format = $this->getCollection()->getPropertyValue('format');
-            if ($expected_format !== null && $this->getFormat() !== null && !in_array($this->getFormat(), $expected_format)) {
-                $expected_format_names = [];
-                foreach ($expected_format as $expected_format_id) {
-                    $expected_format_names[] = DataFormat::getName($expected_format_id);
-                }
-                $this->warning("Found {format_name} data format, expected {expected_format_names}", [
-                    'format_name' => DataFormat::getName($this->getFormat()),
-                    'expected_format_names' => implode(', ', $expected_format_names),
-                ]);
-            }
+            return;
+        }
 
-            // Warn if components are not as expected.
-            $expected_components = $this->getCollection()->getPropertyValue('components');
-            if ($expected_components !== null && $this->getComponents() !== null && $this->getComponents() !== $expected_components) {
-                $this->warning("Found {components} data components, expected {expected_components}", [
-                    'components' => $this->getComponents(),
-                    'expected_components' => $expected_components,
-                ]);
+        // Warn if format is not as expected.
+        $expected_format = $this->getCollection()->getPropertyValue('format');
+        if ($expected_format !== null && $this->getFormat() !== null && !in_array($this->getFormat(), $expected_format)) {
+            $expected_format_names = [];
+            foreach ($expected_format as $expected_format_id) {
+                $expected_format_names[] = DataFormat::getName($expected_format_id);
             }
+            $this->warning("Found {format_name} data format, expected {expected_format_names} for item {item} in '{parent}'", [
+                'format_name' => DataFormat::getName($this->getFormat()),
+                'expected_format_names' => implode(', ', $expected_format_names),
+                'item' => $this->getAttribute('name') ?? 'n/a',
+                'parent' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
+            ]);
+        }
+
+        // Warn if components are not as expected.
+        $expected_components = $this->getCollection()->getPropertyValue('components');
+        if ($expected_components !== null && $this->getComponents() !== null && $this->getComponents() !== $expected_components) {
+            $this->warning("Found {components} data components, expected {expected_components} for item {item} in '{parent}'", [
+                'components' => $this->getComponents(),
+                'expected_components' => $expected_components,
+                'item' => $this->getAttribute('name') ?? 'n/a',
+                'parent' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
+            ]);
         }
     }
 

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -32,10 +32,10 @@ class Tag extends BlockBase
      */
     public function validate()
     {
-        // Check if MediaProbe has a definition for this TAG.
+        // Check if MediaProbe has a definition for this tag.
         if (in_array($this->getCollection()->getId(), ['VoidCollection', 'UnknownTag'])) {
-            $this->notice("Unknown item '{item}' in '{ifd}'", [
 dump($this->getCollection());
+            $this->notice("Unknown item '{item}' in '{ifd}'", [
                 'item' => $this->getCollection()->getId(),
                 'ifd' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
             ]);

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -63,7 +63,7 @@ class Tag extends BlockBase
                 'components' => $this->getComponents(),
                 'expected_components' => $expected_components,
                 'item' => $this->getAttribute('name') ?? 'n/a',
-                'parent' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
+                'parent' => $this->getParentElement() ? $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a' : 'n/a',
             ]);
         }
     }

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -34,9 +34,8 @@ class Tag extends BlockBase
     {
         // Check if MediaProbe has a definition for this tag.
         if (in_array($this->getCollection()->getId(), ['VoidCollection', 'UnknownTag'])) {
-dump($this->getCollection());
-            $this->notice("Unknown item '{item}' in '{ifd}'", [
-                'item' => $this->getCollection()->getId(),
+            $this->notice("Unknown item {item} in '{ifd}'", [
+                'item' => $this->getAttribute('id'),
                 'ifd' => $this->getParentElement()->getCollection()->getPropertyValue('name') ?? 'n/a',
             ]);
         } else {
@@ -149,7 +148,7 @@ dump($this->getCollection());
         if ($item ==! null) {
             $msg .= ' ({item})';
         }
-        $item .= MediaProbe::dumpIntHex($item);
+        $item = MediaProbe::dumpIntHex($item);
         if ($data_element instanceof DataWindow) {
             $msg .= ' @{offset} s {size}';
             $offset = MediaProbe::dumpIntHex($data_element->getAbsoluteOffset());

--- a/src/Data/DataWindow.php
+++ b/src/Data/DataWindow.php
@@ -50,7 +50,7 @@ final class DataWindow extends DataElement
             throw new DataException('Zero or negative size for DataWindow');
         }
         if ($this->size > ($dataElement->getSize() - $offset)) {
-            throw new DataException('Excessive size for DataWindow');
+            throw new DataException('DataWindow (offset: %d size: $s) out of bounds of DataElement (size: %d)', $offset, $size, $dataElement->getSize());
         }
 
         $this->order = $dataElement->getByteOrder();

--- a/src/Data/DataWindow.php
+++ b/src/Data/DataWindow.php
@@ -50,7 +50,7 @@ final class DataWindow extends DataElement
             throw new DataException('Zero or negative size for DataWindow');
         }
         if ($this->size > ($dataElement->getSize() - $offset)) {
-            throw new DataException('DataWindow (offset: %d size: $s) out of bounds of DataElement (size: %d)', $offset, $size, $dataElement->getSize());
+            throw new DataException('DataWindow (offset: %d size: %d) out of bounds of DataElement (size: %d)', $offset, $size, $dataElement->getSize());
         }
 
         $this->order = $dataElement->getByteOrder();

--- a/src/ElementBase.php
+++ b/src/ElementBase.php
@@ -254,9 +254,9 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         $context['path'] = $this->getContextPath();
         $root_element = $this->getRootElement();
 
-        if (method_exists($root_element, 'getStopwatch')) {
+/*        if (method_exists($root_element, 'getStopwatch')) {
             $message = (string) $root_element->getStopwatch()->getEvent('media-parsing') . ' ' . $message;
-        }
+        }*/
 
         if (property_exists($root_element, 'logger')) {  // xx should be logging anyway
             $root_element->logger->log($level, $message, $context);

--- a/src/MediaProbe.php
+++ b/src/MediaProbe.php
@@ -150,4 +150,12 @@ class MediaProbe
 
         return $ret;
     }
+
+    public static function dumpIntHex($data): string
+    {
+        if (is_numeric($data)) {
+            return $data . '/0x' . strtoupper(dechex($data));
+        }
+        return "'$data'";
+    }
 }

--- a/tests/DataWindowTest.php
+++ b/tests/DataWindowTest.php
@@ -71,7 +71,7 @@ class DataWindowTest extends MediaProbeTestCaseBase
         $window_1 = new DataWindow($data, 5, 10);
 
         $this->expectException(DataException::class);
-        $this->expectExceptionMessage('Excessive size for DataWindow');
+        $this->expectExceptionMessage('DataWindow (offset: 0 size: 40) out of bounds of DataElement (size: 10)');
         $window_1_sub3 = new DataWindow($window_1, 0, 40);
     }
 

--- a/tests/media-dumps/image/broken/canon-eos-650d.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/canon-eos-650d.jpg.dump.yml
@@ -5440,7 +5440,7 @@ elements:
                                                                                     format: Long
                                                                                     components: 4
                                                                                     bytesHash: 25617656d8ee33998905ed28a8bc2faf39d3a1f50c47db520af47813b1c78b3e
-                                                                                    text: '-559218682 309395467 -386924534 85262341'
+                                                                                    text: '3735748614 309395467 3908042762 85262341'
                                                                         -
                                                                             node: tag
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:PerChannelBlackLevel:504'
@@ -6687,53 +6687,53 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonCustomFunctions2Header:153/index:Exposure:1/tag:ISOSpeedRange:259'
-            message: 'Found 1 data components, expected 3'
+            message: 'Found 1 data components, expected 3 for item ''ISOSpeedRange'' in ''Exposure'''
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13/tag:FirmwareVersion:544/entry'
             message: 'Ascii entry missing final NUL character.'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 25/0x19 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:LensModel:149/entry'
             message: 'Ascii entry missing final NUL character.'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'No specification for item UnknownTag in ''CanonMeasuredColor'''
+            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16401/0x4011 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16402/0x4012 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16423'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16423/0x4027 in ''Canon'''
 gdInfo:
     0: 640
     1: 427
@@ -6744,7 +6744,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon-eos-650d.jpg
-    FileDateTime: 1644099378
+    FileDateTime: 1644443574
     FileSize: 42207
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/gh-10-a.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/gh-10-a.jpg.dump.yml
@@ -893,13 +893,13 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ModifyDate:306'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''ModifyDate'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:DateTimeOriginal:36867'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''DateTimeOriginal'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:CreateDate:36868'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''CreateDate'' in ''ExifIFD'''
 gdInfo:
     0: 330
     1: 220
@@ -910,7 +910,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-10-a.jpg
-    FileDateTime: 1644099378
+    FileDateTime: 1644443574
     FileSize: 33843
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/gh-10-b.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/gh-10-b.jpg.dump.yml
@@ -1377,14 +1377,6 @@ elements:
                                                                                     components: 1
                                                                                     bytesHash: 96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7
                                                                                     text: Normal
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: SRAWQuality
-                                                                            id: '46'
-                                                                            collection: Tag
                                                                 -
                                                                     node: index
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFocalLength:2'
@@ -1848,9 +1840,6 @@ log:
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665'
             message: 'Offset out of bounds - rel 1564 [0, 1554], abs 1594 [30, 1584]'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-            message: 'Excessive size for DataWindow'
-        -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4'
             message: 'Excessive size for DataWindow'
         -
@@ -1881,6 +1870,9 @@ log:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
             message: 'Size mismatch between IFD and index header'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
+            message: 'Could not access value for item ''SRAWQuality'' in ''CanonCameraSettings'', overflow'
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
@@ -1898,7 +1890,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-10-b.jpg
-    FileDateTime: 1644251684
+    FileDateTime: 1644430552
     FileSize: 12043
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/gh-10-b.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/gh-10-b.jpg.dump.yml
@@ -1477,14 +1477,6 @@ elements:
                                                                             bytesHash: 10f8d94bbf47c09472dbc948640fe8abb24dce82f232d7990f91727a26dfddca
                                                                             text: '384 384 384 384'
                                                                 -
-                                                                    node: map
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4'
-                                                                    class: FileEye\MediaProbe\Block\Map
-                                                                    valid: false
-                                                                    name: CanonShotInfo
-                                                                    id: '4'
-                                                                    collection: ExifMakerNotes\Canon\ShotInfo
-                                                                -
                                                                     node: tag
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:FileNumber:8'
                                                                     class: FileEye\MediaProbe\Block\Tag
@@ -1776,17 +1768,17 @@ log:
     ERROR:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665'
-            message: 'Offset out of bounds - rel 1564 [0, 1554], abs 1594 [30, 1584]'
+            message: 'Offset out of bounds - rel 1572 [0, 1554], abs 1602 [30, 1584]'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
             message: 'Size mismatch between IFD and index header'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4'
-            message: 'DataWindow (offset: 555 size: 68) out of bounds of DataElement (size: 606)'
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
             message: 'Could not access value for item ''SRAWQuality'' in ''CanonCameraSettings'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not get value for item ''CanonShotInfo'' in ''Canon'', not enough data'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
             message: 'Could not access value for item ''n/a'' in ''Canon'', overflow'
@@ -1821,7 +1813,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-10-b.jpg
-    FileDateTime: 1644443574
+    FileDateTime: 1644525798
     FileSize: 12043
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/gh-10-b.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/gh-10-b.jpg.dump.yml
@@ -1486,52 +1486,6 @@ elements:
                                                                     collection: ExifMakerNotes\Canon\ShotInfo
                                                                 -
                                                                     node: tag
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-                                                                    class: FileEye\MediaProbe\Block\Tag
-                                                                    valid: false
-                                                                    id: '0'
-                                                                    collection: UnknownTag
-                                                                -
-                                                                    node: tag
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-                                                                    class: FileEye\MediaProbe\Block\Tag
-                                                                    valid: false
-                                                                    id: '0'
-                                                                    collection: UnknownTag
-                                                                -
-                                                                    node: index
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo:18'
-                                                                    class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\AFInfoIndex
-                                                                    valid: false
-                                                                    name: CanonAFInfo
-                                                                    id: '18'
-                                                                    collection: ExifMakerNotes\Canon\AFInfo
-                                                                -
-                                                                    node: tag
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:ThumbnailImageValidArea:19'
-                                                                    class: FileEye\MediaProbe\Block\Tag
-                                                                    valid: false
-                                                                    name: ThumbnailImageValidArea
-                                                                    id: '19'
-                                                                    collection: Tag
-                                                                -
-                                                                    node: tag
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:CanonImageType:6'
-                                                                    class: FileEye\MediaProbe\Block\Tag
-                                                                    valid: false
-                                                                    name: CanonImageType
-                                                                    id: '6'
-                                                                    collection: Tag
-                                                                -
-                                                                    node: tag
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:CanonFirmwareVersion:7'
-                                                                    class: FileEye\MediaProbe\Block\Tag
-                                                                    valid: false
-                                                                    name: CanonFirmwareVersion
-                                                                    id: '7'
-                                                                    collection: Tag
-                                                                -
-                                                                    node: tag
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:FileNumber:8'
                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                     valid: true
@@ -1550,14 +1504,6 @@ elements:
                                                                             text: 134-3418
                                                                 -
                                                                     node: tag
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:OwnerName:9'
-                                                                    class: FileEye\MediaProbe\Block\Tag
-                                                                    valid: false
-                                                                    name: OwnerName
-                                                                    id: '9'
-                                                                    collection: Tag
-                                                                -
-                                                                    node: tag
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:CanonModelID:16'
                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                     valid: true
@@ -1574,14 +1520,6 @@ elements:
                                                                             components: 1
                                                                             bytesHash: f7fe9c0542b04021d77b6c7472d95490f8a023357c995a7f378b7a8d9e6d6e56
                                                                             text: 'PowerShot G3'
-                                                                -
-                                                                    node: map
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13'
-                                                                    class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\CameraInfoMap
-                                                                    valid: false
-                                                                    name: CanonCameraInfo
-                                                                    id: '13'
-                                                                    collection: ExifMakerNotes\Canon\CameraInfoResolver
                                                         -
                                                             node: tag
                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:UserComment:37510'
@@ -1840,46 +1778,39 @@ log:
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665'
             message: 'Offset out of bounds - rel 1564 [0, 1554], abs 1594 [30, 1584]'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo:18'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:ThumbnailImageValidArea:19'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:CanonImageType:6'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:CanonFirmwareVersion:7'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:OwnerName:9'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13'
-            message: 'Excessive size for DataWindow'
-    WARNING:
-        -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
             message: 'Size mismatch between IFD and index header'
         -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4'
+            message: 'DataWindow (offset: 555 size: 68) out of bounds of DataElement (size: 606)'
+    WARNING:
+        -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
             message: 'Could not access value for item ''SRAWQuality'' in ''CanonCameraSettings'', overflow'
-    NOTICE:
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''n/a'' in ''Canon'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''n/a'' in ''Canon'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''CanonAFInfo'' in ''Canon'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''ThumbnailImageValidArea'' in ''Canon'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''CanonImageType'' in ''Canon'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''CanonFirmwareVersion'' in ''Canon'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''OwnerName'' in ''Canon'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500'
+            message: 'Could not access value for item ''CanonCameraInfo'' in ''Canon'', overflow'
 gdInfo:
     0: 150
     1: 150
@@ -1890,7 +1821,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-10-b.jpg
-    FileDateTime: 1644430552
+    FileDateTime: 1644443574
     FileSize: 12043
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/gh-11.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/gh-11.jpg.dump.yml
@@ -1545,65 +1545,65 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:XResolution:282'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''XResolution'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:YResolution:283'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''YResolution'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ModifyDate:306'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''ModifyDate'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:ExposureTime:33434'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''ExposureTime'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:FNumber:33437'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''FNumber'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:DateTimeOriginal:36867'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''DateTimeOriginal'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:CreateDate:36868'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''CreateDate'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:CompressedBitsPerPixel:37122'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''CompressedBitsPerPixel'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:MaxApertureValue:37381'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''MaxApertureValue'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:FocalLength:37386'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''FocalLength'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:ExposureTime:33434'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''ExposureTime'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:FNumber:33437'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''FNumber'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:DateTimeOriginal:36867'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''DateTimeOriginal'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:CreateDate:36868'
-            message: 'Found 21 data components, expected 20'
+            message: 'Found 21 data components, expected 20 for item ''CreateDate'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:CompressedBitsPerPixel:37122'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''CompressedBitsPerPixel'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:MaxApertureValue:37381'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''MaxApertureValue'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:FocalLength:37386'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''FocalLength'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:ExifImageWidth:40962'
-            message: 'Found Long data format, expected Short'
+            message: 'Found Long data format, expected Short for item ''ExifImageWidth'' in ''InteropIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:ExifImageHeight:40963'
-            message: 'Found Long data format, expected Short'
+            message: 'Found Long data format, expected Short for item ''ExifImageHeight'' in ''InteropIFD'''
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/ifd:InteropIFD:40965/tag:40965'
-            message: 'No specification for item UnknownTag in ''InteropIFD'''
+            message: 'Unknown item 40965/0xA005 in ''InteropIFD'''
 gdInfo:
     0: 50
     1: 38
@@ -1614,7 +1614,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-11.jpg
-    FileDateTime: 1644099378
+    FileDateTime: 1644443574
     FileSize: 4304
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/misplaced-exif.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/misplaced-exif.jpg.dump.yml
@@ -428,13 +428,13 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ModifyDate:306'
-            message: 'Found 11 data components, expected 20'
+            message: 'Found 11 data components, expected 20 for item ''ModifyDate'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ModifyDate:306/entry'
             message: 'Invalid datetime format for ''1509749992'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:ExifVersion:36864'
-            message: 'Found Byte data format, expected Undefined'
+            message: 'Found Byte data format, expected Undefined for item ''ExifVersion'' in ''ExifIFD'''
 gdInfo:
     0: 320
     1: 200
@@ -445,7 +445,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: misplaced-exif.jpg
-    FileDateTime: 1644099378
+    FileDateTime: 1644443574
     FileSize: 4587
     FileType: 2
     MimeType: image/jpeg
@@ -458,7 +458,7 @@ exifReadData:
         ByteOrderMotorola: 0
         Thumbnail.FileType: 2
         Thumbnail.MimeType: image/jpeg
-    Title: ''
+    Title: '?'
     ImageDescription: Test1
     DateTime: '1509749992'
     GPS_IFD_Pointer: 91

--- a/tests/media-dumps/image/broken/misplaced-exif.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/misplaced-exif.jpg.dump.yml
@@ -458,7 +458,7 @@ exifReadData:
         ByteOrderMotorola: 0
         Thumbnail.FileType: 2
         Thumbnail.MimeType: image/jpeg
-    Title: '?'
+    Title: ''
     ImageDescription: Test1
     DateTime: '1509749992'
     GPS_IFD_Pointer: 91

--- a/tests/media-dumps/image/broken/pel-141.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/pel-141.jpg.dump.yml
@@ -872,25 +872,25 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ExifVersion:36864'
-            message: 'Found Byte data format, expected Undefined'
+            message: 'Found Byte data format, expected Undefined for item ''ExifVersion'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ExposureTime:33434'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''ExposureTime'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ComponentsConfiguration:37121'
-            message: 'Found Byte data format, expected Undefined'
+            message: 'Found Byte data format, expected Undefined for item ''ComponentsConfiguration'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:FNumber:33437'
-            message: 'Found SignedRational data format, expected Rational'
+            message: 'Found SignedRational data format, expected Rational for item ''FNumber'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:UserComment:37510'
-            message: 'Found Ascii data format, expected Undefined'
+            message: 'Found Ascii data format, expected Undefined for item ''UserComment'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:OtherImageStart:513'
-            message: 'Found Long data format, expected Undefined'
+            message: 'Found Long data format, expected Undefined for item ''OtherImageStart'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:OtherImageLength:514'
-            message: 'Found Long data format, expected Undefined'
+            message: 'Found Long data format, expected Undefined for item ''OtherImageLength'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:SOS:218'
             message: 'Found trailing content after EOI: 3504 bytes'
@@ -904,7 +904,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: pel-141.jpg
-    FileDateTime: 1644099378
+    FileDateTime: 1644443574
     FileSize: 1167394
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/pel-152.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/pel-152.jpg.dump.yml
@@ -264,7 +264,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: pel-152.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 17694
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/pel-156.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/pel-156.jpg.dump.yml
@@ -1562,7 +1562,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: pel-156.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 448078
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/broken/pel-176-RPT200076_03.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/pel-176-RPT200076_03.jpg.dump.yml
@@ -919,16 +919,16 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:ModifyDate:306'
-            message: 'Found 19 data components, expected 20'
+            message: 'Found 19 data components, expected 20 for item ''ModifyDate'' in ''IFD0'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:DateTimeOriginal:36867'
-            message: 'Found 19 data components, expected 20'
+            message: 'Found 19 data components, expected 20 for item ''DateTimeOriginal'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:CreateDate:36868'
-            message: 'Found 19 data components, expected 20'
+            message: 'Found 19 data components, expected 20 for item ''CreateDate'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:OffsetTime:36880'
-            message: 'Found 6 data components, expected 7'
+            message: 'Found 6 data components, expected 7 for item ''OffsetTime'' in ''ExifIFD'''
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/tag:Make:271/entry'
@@ -979,7 +979,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: pel-176-RPT200076_03.jpg
-    FileDateTime: 1644226017
+    FileDateTime: 1644443574
     FileSize: 53475
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/bug3017880.jpg.dump.yml
+++ b/tests/media-dumps/image/bug3017880.jpg.dump.yml
@@ -185,7 +185,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: bug3017880.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443593
     FileSize: 4900
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/apple-iphone11.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/apple-iphone11.jpg.dump.yml
@@ -1887,79 +1887,79 @@ log:
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:42080'
-            message: 'No specification for item UnknownTag in ''ExifIFD'''
+            message: 'Unknown item 42080/0xA460 in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:1'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 1/0x1 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:2'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 2/0x2 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:4'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 4/0x4 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:5'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 5/0x5 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:6'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 6/0x6 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:7'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 7/0x7 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:12'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 12/0xC in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:13'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 13/0xD in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:14'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 14/0xE in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:16'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 16/0x10 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:20'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 20/0x14 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:22'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 22/0x16 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:23'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 23/0x17 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 25/0x19 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:26'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 26/0x1A in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:31'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 31/0x1F in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:32'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 32/0x20 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:33'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 33/0x21 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:35'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 35/0x23 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:37'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 37/0x25 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:38'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 38/0x26 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:39'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 39/0x27 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:40'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 40/0x28 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:43'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 43/0x2B in ''Apple'''
 gdInfo:
     0: 4032
     1: 3024
@@ -1970,7 +1970,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: apple-iphone11.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 4233685
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/apple-iphone6s.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/apple-iphone6s.jpg.dump.yml
@@ -1630,40 +1630,40 @@ log:
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:1'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 1/0x1 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:2'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 2/0x2 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:4'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 4/0x4 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:5'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 5/0x5 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:6'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 6/0x6 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:7'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 7/0x7 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:9'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 9/0x9 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:14'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 14/0xE in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:20'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 20/0x14 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:23'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 23/0x17 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 25/0x19 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:31'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 31/0x1F in ''Apple'''
 gdInfo:
     0: 4032
     1: 3024
@@ -1674,7 +1674,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: apple-iphone6s.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 1812177
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/apple-iphone7.JPG.dump.yml
+++ b/tests/media-dumps/image/camera/apple-iphone7.JPG.dump.yml
@@ -1673,52 +1673,52 @@ log:
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:1'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 1/0x1 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:2'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 2/0x2 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:4'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 4/0x4 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:5'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 5/0x5 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:6'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 6/0x6 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:7'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 7/0x7 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:12'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 12/0xC in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:13'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 13/0xD in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:14'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 14/0xE in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:16'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 16/0x10 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:20'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 20/0x14 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:22'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 22/0x16 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:23'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 23/0x17 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 25/0x19 in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:26'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 26/0x1A in ''Apple'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Apple:37500/tag:31'
-            message: 'No specification for item UnknownTag in ''Apple'''
+            message: 'Unknown item 31/0x1F in ''Apple'''
 gdInfo:
     0: 4032
     1: 3024
@@ -1729,7 +1729,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: apple-iphone7.JPG
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 3663872
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon-ixus-ii.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon-ixus-ii.jpg.dump.yml
@@ -1164,14 +1164,6 @@ elements:
                                                                                     components: 1
                                                                                     bytesHash: 8f96c15501bef61baf5bd943201979595736b66b6a7e3b35c353729ab8d9a561
                                                                                     text: '32767'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: SRAWQuality
-                                                                            id: '46'
-                                                                            collection: Tag
                                                                 -
                                                                     node: index
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFocalLength:2'
@@ -2194,14 +2186,6 @@ elements:
                                                                                     components: 68
                                                                                     bytesHash: 330051d664cf9db8961ab0725e8514d7899b9941e449a752471b4b76b69932c1
                                                                                     text: '68 byte(s) of data'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13/tag:LensSerialNumber:363'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: LensSerialNumber
-                                                                            id: '363'
-                                                                            collection: Tag
                                                         -
                                                             node: tag
                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:UserComment:37510'
@@ -2741,13 +2725,13 @@ elements:
                             bytesHash: cde66e78e5419dea74df7cf43d9aa876b8c669d40067992e719cef90ac5f3fe0
                             text: '2 byte(s) of data'
 log:
-    ERROR:
+    WARNING:
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
+            message: 'Could not access value for item ''SRAWQuality'' in ''CanonCameraSettings'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13/tag:LensSerialNumber:363'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13'
+            message: 'Could not access value for item ''LensSerialNumber'' in ''CanonCameraInfo'', overflow'
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
@@ -2765,7 +2749,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon-ixus-ii.jpg
-    FileDateTime: 1644251684
+    FileDateTime: 1644430552
     FileSize: 37553
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon-ixus-ii.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon-ixus-ii.jpg.dump.yml
@@ -2735,10 +2735,10 @@ log:
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 0/0x0 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 0/0x0 in ''Canon'''
 gdInfo:
     0: 640
     1: 480
@@ -2749,7 +2749,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon-ixus-ii.jpg
-    FileDateTime: 1644430552
+    FileDateTime: 1644443574
     FileSize: 37553
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon-powershot-s60.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon-powershot-s60.jpg.dump.yml
@@ -2786,19 +2786,19 @@ log:
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 0/0x0 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 0/0x0 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 0/0x0 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:24'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 24/0x18 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 25/0x19 in ''Canon'''
 gdInfo:
     0: 640
     1: 480
@@ -2809,7 +2809,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon-powershot-s60.jpg
-    FileDateTime: 1644430552
+    FileDateTime: 1644443574
     FileSize: 42616
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon-powershot-s60.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon-powershot-s60.jpg.dump.yml
@@ -1164,14 +1164,6 @@ elements:
                                                                                     components: 1
                                                                                     bytesHash: 8f96c15501bef61baf5bd943201979595736b66b6a7e3b35c353729ab8d9a561
                                                                                     text: '32767'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: SRAWQuality
-                                                                            id: '46'
-                                                                            collection: Tag
                                                                 -
                                                                     node: index
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFocalLength:2'
@@ -2245,14 +2237,6 @@ elements:
                                                                                     components: 72
                                                                                     bytesHash: 1fba6cd7622c3af713e0532b93c8c297b49514e1c92b49b0aad3d453ca4cb364
                                                                                     text: '72 byte(s) of data'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13/tag:LensSerialNumber:363'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: LensSerialNumber
-                                                                            id: '363'
-                                                                            collection: Tag
                                                         -
                                                             node: tag
                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:UserComment:37510'
@@ -2792,13 +2776,13 @@ elements:
                             bytesHash: cde66e78e5419dea74df7cf43d9aa876b8c669d40067992e719cef90ac5f3fe0
                             text: '2 byte(s) of data'
 log:
-    ERROR:
+    WARNING:
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
+            message: 'Could not access value for item ''SRAWQuality'' in ''CanonCameraSettings'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13/tag:LensSerialNumber:363'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13'
+            message: 'Could not access value for item ''LensSerialNumber'' in ''CanonCameraInfo'', overflow'
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
@@ -2825,7 +2809,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon-powershot-s60.jpg
-    FileDateTime: 1644251684
+    FileDateTime: 1644430552
     FileSize: 42616
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon_eos_70d_29.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon_eos_70d_29.jpg.dump.yml
@@ -7234,50 +7234,50 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonCustomFunctions2Header:153/index:AutoFocusDrive:3/tag:AFMicroadjustment:1287'
-            message: 'Found 16 data components, expected 5'
+            message: 'Found 16 data components, expected 5 for item ''AFMicroadjustment'' in ''AutoFocusDrive'''
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 25/0x19 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:LensModel:149/entry'
             message: 'Ascii entry missing final NUL character.'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'No specification for item UnknownTag in ''CanonMeasuredColor'''
+            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16401/0x4011 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16402/0x4012 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16423'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16423/0x4027 in ''Canon'''
 gdInfo:
     0: 5472
     1: 3648
@@ -7288,7 +7288,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon_eos_70d_29.jpg
-    FileDateTime: 1644226017
+    FileDateTime: 1644443574
     FileSize: 7643244
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon_eos_850d_08.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon_eos_850d_08.jpg.dump.yml
@@ -7416,110 +7416,110 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonCustomFunctions2Header:153/index:Exposure:1/tag:ISOSpeedRange:259'
-            message: 'Found 1 data components, expected 3'
+            message: 'Found 1 data components, expected 3 for item ''ISOSpeedRange'' in ''Exposure'''
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 25/0x19 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:17'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 17/0x11 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:18'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 18/0x12 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:19'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 19/0x13 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:20'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 20/0x14 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:21'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 21/0x15 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:22'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 22/0x16 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:23'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 23/0x17 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:50'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 50/0x32 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:51'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 51/0x33 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:61'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 61/0x3D in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:63'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 63/0x3F in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:14'
-            message: 'No specification for item UnknownTag in ''CanonProcessing'''
+            message: 'Unknown item 14/0xE in ''CanonProcessing'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonProcessing'''
+            message: 'Unknown item 15/0xF in ''CanonProcessing'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonProcessing'''
+            message: 'Unknown item 16/0x10 in ''CanonProcessing'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:17'
-            message: 'No specification for item UnknownTag in ''CanonProcessing'''
+            message: 'Unknown item 17/0x11 in ''CanonProcessing'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'No specification for item UnknownTag in ''CanonMeasuredColor'''
+            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16401/0x4011 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16402/0x4012 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16423'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16423/0x4027 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16428'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16428/0x402C in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16435'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16435/0x4033 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16441'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16441/0x4039 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16444'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16444/0x403C in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16445'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16445/0x403D in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16457'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16457/0x4049 in ''Canon'''
 gdInfo:
     0: 6000
     1: 4000
@@ -7530,7 +7530,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon_eos_850d_08.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 8746090
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/fujifilm_x_a5.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/fujifilm_x_a5.jpg.dump.yml
@@ -1528,7 +1528,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: fujifilm_x_a5.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 23108
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/konica-minolta-dimage-a2.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/konica-minolta-dimage-a2.jpg.dump.yml
@@ -1407,7 +1407,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: konica-minolta-dimage-a2.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 209855
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/leica-d-lux.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/leica-d-lux.jpg.dump.yml
@@ -1200,7 +1200,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: leica-d-lux.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 70095
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/nikon-coolscan-iv.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/nikon-coolscan-iv.jpg.dump.yml
@@ -454,7 +454,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: nikon-coolscan-iv.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 69524
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/nikon-d50.JPG.dump.yml
+++ b/tests/media-dumps/image/camera/nikon-d50.JPG.dump.yml
@@ -1182,7 +1182,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: nikon-d50.JPG
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 1276372
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/nikon-e5000.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/nikon-e5000.jpg.dump.yml
@@ -931,7 +931,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: nikon-e5000.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 317985
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/nikon-e950.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/nikon-e950.jpg.dump.yml
@@ -984,7 +984,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: nikon-e950.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 351451
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/olympus-c5050z.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/olympus-c5050z.jpg.dump.yml
@@ -1092,7 +1092,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: olympus-c5050z.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 53704
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/olympus-c50z.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/olympus-c50z.jpg.dump.yml
@@ -1146,7 +1146,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: olympus-c50z.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 60482
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/olympus-c765uz.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/olympus-c765uz.jpg.dump.yml
@@ -1182,7 +1182,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: olympus-c765uz.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 60380
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/pentax-istDS.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/pentax-istDS.jpg.dump.yml
@@ -1127,7 +1127,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: pentax-istDS.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 173014
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/sony-dsc-v1.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/sony-dsc-v1.jpg.dump.yml
@@ -1060,7 +1060,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: sony-dsc-v1.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 60824
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/exiftool/Canon.jpg.dump.yml
+++ b/tests/media-dumps/image/exiftool/Canon.jpg.dump.yml
@@ -1196,14 +1196,6 @@ elements:
                                                                                     components: 1
                                                                                     bytesHash: 96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7
                                                                                     text: Normal
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: SRAWQuality
-                                                                            id: '46'
-                                                                            collection: Tag
                                                                 -
                                                                     node: index
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFocalLength:2'
@@ -1815,14 +1807,6 @@ elements:
                                                                                     components: 1
                                                                                     bytesHash: 96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7
                                                                                     text: '0'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4/tag:FlashOutput:33'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: FlashOutput
-                                                                            id: '33'
-                                                                            collection: Tag
                                                                 -
                                                                     node: map
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
@@ -1975,86 +1959,6 @@ elements:
                                                                                     components: 1
                                                                                     bytesHash: ca2fd00fa001190744c15c317643ab092e7048ce086a243e2be9437c898de1bb
                                                                                     text: '-1'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:WBBracketMode:9'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: WBBracketMode
-                                                                            id: '9'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:WBBracketValueAB:12'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: WBBracketValueAB
-                                                                            id: '12'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:WBBracketValueGM:13'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: WBBracketValueGM
-                                                                            id: '13'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FilterEffect:14'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: FilterEffect
-                                                                            id: '14'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:ToningEffect:15'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: ToningEffect
-                                                                            id: '15'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:MacroMagnification:16'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: MacroMagnification
-                                                                            id: '16'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:LiveViewShooting:19'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: LiveViewShooting
-                                                                            id: '19'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FocusDistanceUpper:20'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: FocusDistanceUpper
-                                                                            id: '20'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FocusDistanceLower:21'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: FocusDistanceLower
-                                                                            id: '21'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FlashExposureLock:25'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: FlashExposureLock
-                                                                            id: '25'
-                                                                            collection: Tag
                                                                 -
                                                                     node: tag
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:CanonImageType:6'
@@ -3299,43 +3203,43 @@ elements:
                             bytesHash: cde66e78e5419dea74df7cf43d9aa876b8c669d40067992e719cef90ac5f3fe0
                             text: '2 byte(s) of data'
 log:
-    ERROR:
+    WARNING:
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1/tag:SRAWQuality:46'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraSettings:1'
+            message: 'Could not access value for item ''SRAWQuality'' in ''CanonCameraSettings'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4/tag:FlashOutput:33'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonShotInfo:4'
+            message: 'Could not access value for item ''FlashOutput'' in ''CanonShotInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:WBBracketMode:9'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''WBBracketMode'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:WBBracketValueAB:12'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''WBBracketValueAB'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:WBBracketValueGM:13'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''WBBracketValueGM'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FilterEffect:14'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''FilterEffect'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:ToningEffect:15'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''ToningEffect'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:MacroMagnification:16'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''MacroMagnification'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:LiveViewShooting:19'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''LiveViewShooting'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FocusDistanceUpper:20'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''FocusDistanceUpper'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FocusDistanceLower:21'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''FocusDistanceLower'' in ''CanonFileInfo'', overflow'
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FlashExposureLock:25'
-            message: 'Excessive size for DataWindow'
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''FlashExposureLock'' in ''CanonFileInfo'', overflow'
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
@@ -3365,7 +3269,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: Canon.jpg
-    FileDateTime: 1644251684
+    FileDateTime: 1644430552
     FileSize: 2697
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/exiftool/Canon.jpg.dump.yml
+++ b/tests/media-dumps/image/exiftool/Canon.jpg.dump.yml
@@ -3243,22 +3243,22 @@ log:
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 0/0x0 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:192'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 192/0xC0 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:193'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 193/0xC1 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:168'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 168/0xA8 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:181'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 181/0xB5 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:0'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 0/0x0 in ''Canon'''
 gdInfo:
     0: 8
     1: 8
@@ -3269,7 +3269,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: Canon.jpg
-    FileDateTime: 1644430552
+    FileDateTime: 1644443574
     FileSize: 2697
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/exiftool/Canon1DmkIII.jpg.dump.yml
+++ b/tests/media-dumps/image/exiftool/Canon1DmkIII.jpg.dump.yml
@@ -3062,14 +3062,6 @@ elements:
                                                                                     components: 1
                                                                                     bytesHash: d98ef49a7788d78f0492028759b34a721d827d1c2ca22b6f688e6570fdc155f0
                                                                                     text: '1.13 m'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FlashExposureLock:25'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: FlashExposureLock
-                                                                            id: '25'
-                                                                            collection: Tag
                                                                 -
                                                                     node: tag
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:LensModel:149'
@@ -5123,94 +5115,6 @@ elements:
                                                                                     components: 4
                                                                                     bytesHash: 178c22fd3b5a204079ac4acbea2077ea4894f7430abefc0fe33fe77439eea16a
                                                                                     text: '294111 455756 464315 279659'
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:PerChannelBlackLevel:692'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: PerChannelBlackLevel
-                                                                            id: '692'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:NormalWhiteLevel:696'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: NormalWhiteLevel
-                                                                            id: '696'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:SpecularWhiteLevel:697'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: SpecularWhiteLevel
-                                                                            id: '697'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:LinearityUpperMargin:698'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: LinearityUpperMargin
-                                                                            id: '698'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:PerChannelBlackLevel:715'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: PerChannelBlackLevel
-                                                                            id: '715'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:NormalWhiteLevel:719'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: NormalWhiteLevel
-                                                                            id: '719'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:SpecularWhiteLevel:720'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: SpecularWhiteLevel
-                                                                            id: '720'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:LinearityUpperMargin:721'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: LinearityUpperMargin
-                                                                            id: '721'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:NormalWhiteLevel:723'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: NormalWhiteLevel
-                                                                            id: '723'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:SpecularWhiteLevel:724'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: SpecularWhiteLevel
-                                                                            id: '724'
-                                                                            collection: Tag
-                                                                        -
-                                                                            node: tag
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:LinearityUpperMargin:725'
-                                                                            class: FileEye\MediaProbe\Block\Tag
-                                                                            valid: false
-                                                                            name: LinearityUpperMargin
-                                                                            id: '725'
-                                                                            collection: Tag
                                                                 -
                                                                     node: tag
                                                                     path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:PictureStyleUserDef:16392'
@@ -5912,44 +5816,45 @@ elements:
 log:
     ERROR:
         -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147/tag:FlashExposureLock:25'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:PerChannelBlackLevel:692'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:NormalWhiteLevel:696'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:SpecularWhiteLevel:697'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:LinearityUpperMargin:698'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:PerChannelBlackLevel:715'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:NormalWhiteLevel:719'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:SpecularWhiteLevel:720'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:LinearityUpperMargin:721'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:NormalWhiteLevel:723'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:SpecularWhiteLevel:724'
-            message: 'Excessive size for DataWindow'
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385/tag:LinearityUpperMargin:725'
-            message: 'Excessive size for DataWindow'
-        -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD1:1'
             message: 'Offset out of bounds - rel -1 [0, 27], abs 8059 [8060, 8087]'
+    WARNING:
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
+            message: 'Could not access value for item ''FlashExposureLock'' in ''CanonFileInfo'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''PerChannelBlackLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''NormalWhiteLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''SpecularWhiteLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''LinearityUpperMargin'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''PerChannelBlackLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''NormalWhiteLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''SpecularWhiteLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''LinearityUpperMargin'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''NormalWhiteLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''SpecularWhiteLevel'' in ''CanonColorData'', overflow'
+        -
+            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
+            message: 'Could not access value for item ''LinearityUpperMargin'' in ''CanonColorData'', overflow'
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
@@ -6003,7 +5908,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: Canon1DmkIII.jpg
-    FileDateTime: 1644251684
+    FileDateTime: 1644430552
     FileSize: 8337
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/exiftool/Canon1DmkIII.jpg.dump.yml
+++ b/tests/media-dumps/image/exiftool/Canon1DmkIII.jpg.dump.yml
@@ -5858,46 +5858,46 @@ log:
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 25/0x19 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:17'
-            message: 'No specification for item UnknownTag in ''CanonAFInfo2'''
+            message: 'Unknown item 17/0x11 in ''CanonAFInfo2'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'No specification for item UnknownTag in ''CanonMeasuredColor'''
+            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'No specification for item UnknownTag in ''CanonSensorInfo'''
+            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16401/0x4011 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16402/0x4012 in ''Canon'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16404'
-            message: 'No specification for item UnknownTag in ''Canon'''
+            message: 'Unknown item 16404/0x4014 in ''Canon'''
 gdInfo:
     0: 8
     1: 8
@@ -5908,7 +5908,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: Canon1DmkIII.jpg
-    FileDateTime: 1644430552
+    FileDateTime: 1644443574
     FileSize: 8337
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/gh-16.jpg.dump.yml
+++ b/tests/media-dumps/image/gh-16.jpg.dump.yml
@@ -282,6 +282,7 @@ elements:
                             components: 2
                             bytesHash: cde66e78e5419dea74df7cf43d9aa876b8c669d40067992e719cef90ac5f3fe0
                             text: '2 byte(s) of data'
+log: {  }
 gdInfo:
     0: 600
     1: 600
@@ -292,7 +293,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-16.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 119734
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/gh-21.jpg.dump.yml
+++ b/tests/media-dumps/image/gh-21.jpg.dump.yml
@@ -282,6 +282,7 @@ elements:
                             components: 2
                             bytesHash: cde66e78e5419dea74df7cf43d9aa876b8c669d40067992e719cef90ac5f3fe0
                             text: '2 byte(s) of data'
+log: {  }
 gdInfo:
     0: 600
     1: 600
@@ -292,7 +293,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-21.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 119734
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/gh-77.jpg.dump.yml
+++ b/tests/media-dumps/image/gh-77.jpg.dump.yml
@@ -1130,7 +1130,7 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:RecommendedExposureIndex:34866'
-            message: 'Found Short data format, expected Long'
+            message: 'Found Short data format, expected Long for item ''RecommendedExposureIndex'' in ''ExifIFD'''
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD1:1'
             message: 'Decrementing thumbnail size to 5315 bytes'
@@ -1178,7 +1178,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: gh-77.jpg
-    FileDateTime: 1644226017
+    FileDateTime: 1644443574
     FileSize: 826602
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/no-exif.jpg.dump.yml
+++ b/tests/media-dumps/image/no-exif.jpg.dump.yml
@@ -232,6 +232,7 @@ elements:
                             components: 2
                             bytesHash: cde66e78e5419dea74df7cf43d9aa876b8c669d40067992e719cef90ac5f3fe0
                             text: '2 byte(s) of data'
+log: {  }
 gdInfo:
     0: 256
     1: 256
@@ -242,7 +243,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: no-exif.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 4348
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/pel-157.tiff.dump.yml
+++ b/tests/media-dumps/image/pel-157.tiff.dump.yml
@@ -1644,53 +1644,53 @@ log:
     WARNING:
         -
             path: '/media/tiff/ifd:IFD0:0/tag:ExtraSamples:338'
-            message: 'Found Short data format, expected Undefined'
+            message: 'Found Short data format, expected Undefined for item ''ExtraSamples'' in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/tag:BrightnessValue:37379'
-            message: 'Found Rational data format, expected SignedRational'
+            message: 'Found Rational data format, expected SignedRational for item ''BrightnessValue'' in ''ExifIFD'''
         -
             path: '/media/tiff/ifd:IFD0:0/ifd:GPS:34853/tag:GPSVersionID:0'
-            message: 'Found Undefined data format, expected Byte'
+            message: 'Found Undefined data format, expected Byte for item ''GPSVersionID'' in ''GPS'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:ExifImageWidth:40962'
-            message: 'Found Long data format, expected Short'
+            message: 'Found Long data format, expected Short for item ''ExifImageWidth'' in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:ExifImageHeight:40963'
-            message: 'Found Long data format, expected Short'
+            message: 'Found Long data format, expected Short for item ''ExifImageHeight'' in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:FocalLengthIn35mmFormat:41989'
-            message: 'Found Long data format, expected Short'
+            message: 'Found Long data format, expected Short for item ''FocalLengthIn35mmFormat'' in ''IFD0'''
     NOTICE:
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20507'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20507/0x501B in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20512'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20512/0x5020 in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20513'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20513/0x5021 in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20515'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20515/0x5023 in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20521'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20521/0x5029 in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20525'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20525/0x502D in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20526'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20526/0x502E in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20528'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20528/0x5030 in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20624'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20624/0x5090 in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:20625'
-            message: 'No specification for item UnknownTag in ''IFD0'''
+            message: 'Unknown item 20625/0x5091 in ''IFD0'''
 gdInfo:
     0: 3264
     1: 1836
@@ -1699,7 +1699,7 @@ gdInfo:
     mime: image/tiff
 exifReadData:
     FileName: pel-157.tiff
-    FileDateTime: 1644411466
+    FileDateTime: 1644443574
     FileSize: 4239700
     FileType: 7
     MimeType: image/tiff

--- a/tests/media-dumps/image/sample-1.tiff.dump.yml
+++ b/tests/media-dumps/image/sample-1.tiff.dump.yml
@@ -323,10 +323,10 @@ log:
     WARNING:
         -
             path: '/media/tiff/ifd:IFD0:0/tag:ExtraSamples:338'
-            message: 'Found Short data format, expected Undefined'
+            message: 'Found Short data format, expected Undefined for item ''ExtraSamples'' in ''IFD0'''
         -
             path: '/media/tiff/ifd:IFD0:0/tag:SampleFormat:339'
-            message: 'Found Short data format, expected Undefined'
+            message: 'Found Short data format, expected Undefined for item ''SampleFormat'' in ''IFD0'''
 gdInfo:
     0: 174
     1: 38
@@ -335,7 +335,7 @@ gdInfo:
     mime: image/tiff
 exifReadData:
     FileName: sample-1.tiff
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 6925
     FileType: 8
     MimeType: image/tiff

--- a/tests/media-dumps/image/test-tags-1.jpg.dump.yml
+++ b/tests/media-dumps/image/test-tags-1.jpg.dump.yml
@@ -586,6 +586,7 @@ elements:
                             components: 2
                             bytesHash: cde66e78e5419dea74df7cf43d9aa876b8c669d40067992e719cef90ac5f3fe0
                             text: '2 byte(s) of data'
+log: {  }
 gdInfo:
     0: 320
     1: 200
@@ -596,7 +597,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: test-tags-1.jpg
-    FileDateTime: 1644099377
+    FileDateTime: 1644443574
     FileSize: 4385
     FileType: 2
     MimeType: image/jpeg


### PR DESCRIPTION
Fixes #54 