### PR TITLE
Dev 230721

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.1"
+#          - "8.1"
           - "8.2"
-          - "8.3"
+#          - "8.3"
 
     steps:
     - name: Install PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-#          - "8.1"
+          - "8.1"
           - "8.2"
-#          - "8.3"
+          - "8.3"
 
     steps:
     - name: Install PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,14 +71,14 @@ jobs:
 
 # Remove the comment to the lines below during development, to refresh the
 # media file dumps.
-#    - name: Update media dumps
-#      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
+    - name: Update media dumps
+      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
 
-#    - name: Upload media dumps
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: media-dumps
-#        path: tests/media-dumps/**/*.yml
+    - name: Upload media dumps
+      uses: actions/upload-artifact@v3
+      with:
+        name: media-dumps
+        path: tests/media-dumps/**/*.yml
 
 #    - name: "Install PHPStan"
 #      run: "composer require --dev phpstan/phpstan:^1.2 --ansi"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
 #        php examples/dump-media.php -d tests/media-samples/image/broken/pel-176-RPT200076_03.jpg
 
     - name: Run test suite
-#      continue-on-error: true
+      continue-on-error: true
       run: vendor/bin/phpunit ./tests
 
 #    - name: Code style test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
 #        php examples/dump-media.php -d tests/media-samples/image/broken/pel-176-RPT200076_03.jpg
 
     - name: Run test suite
-      continue-on-error: true
+#      continue-on-error: true
       run: vendor/bin/phpunit ./tests
 
 #    - name: Code style test
@@ -71,14 +71,14 @@ jobs:
 
 # Remove the comment to the lines below during development, to refresh the
 # media file dumps.
-    - name: Update media dumps
-      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
+#    - name: Update media dumps
+#      run: php bin/fileeye-mediaprobe dump tests/media-samples tests/media-dumps
 
-    - name: Upload media dumps
-      uses: actions/upload-artifact@v3
-      with:
-        name: media-dumps
-        path: tests/media-dumps/**/*.yml
+#    - name: Upload media dumps
+#      uses: actions/upload-artifact@v3
+#      with:
+#        name: media-dumps
+#        path: tests/media-dumps/**/*.yml
 
 #    - name: "Install PHPStan"
 #      run: "composer require --dev phpstan/phpstan:^1.2 --ansi"

--- a/specs/ExifMakerNotes/Canon/FilterInfo.yaml
+++ b/specs/ExifMakerNotes/Canon/FilterInfo.yaml
@@ -2,7 +2,7 @@ collection: ExifMakerNotes\Canon\FilterInfo
 name: CanonFilterInfo
 title: 'Canon FilterInfo'
 class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\FilterInfoIndex
-DOMNode: index
+DOMNode: filterInfo
 defaultItemCollection: Tag
 compiler:
     exiftool:

--- a/src/Block/Exif/Exif.php
+++ b/src/Block/Exif/Exif.php
@@ -33,6 +33,7 @@ class Exif extends BlockBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         if (Tiff::getTiffSegmentByteOrder($data, strlen(self::EXIF_HEADER)) !== null) {
             $tiff = new ItemDefinition(CollectionFactory::get('Tiff\Tiff'));
             $this->addBlock($tiff)->parseData($data, strlen(self::EXIF_HEADER), $data->getSize() - strlen(self::EXIF_HEADER));

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -447,7 +447,7 @@ class Ifd extends ListBase
 
         if (isset($parentInfo['item'])) {
             $msg .= ' ({item})';
-            $info['item'] = is_numeric($info['item']) ? $info['item'] . '/0x' . strtoupper(dechex($info['item'])) : $info['item'];
+            $info['item'] = is_numeric($parentInfo['item']) ? $parentInfo['item'] . '/0x' . strtoupper(dechex($parentInfo['item'])) : $parentInfo['item'];
         }
 
         if (isset($context['dataElement']) && $context['dataElement'] instanceof DataWindow) {

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -445,11 +445,10 @@ class Ifd extends ListBase
             $info['seq'] = $parent_name . '.' . $info['seq'];
         }
 
-        $item = $this->getAttribute('id');
-        if ($item ==! null) {
+        if (isset($parentInfo['item'])) {
             $msg .= ' ({item})';
+            $info['item'] = is_numeric($info['item']) ? $info['item'] . '/0x' . strtoupper(dechex($info['item'])) : $info['item'];
         }
-        $info['item'] = is_numeric($item) ? $item . '/0x' . strtoupper(dechex($item)) : $item;
 
         if (isset($context['dataElement']) && $context['dataElement'] instanceof DataWindow) {
             $info['offset'] = $context['dataElement']->getAbsoluteOffset($this->getDefinition()->getDataOffset()) . '/0x' . strtoupper(dechex($context['dataElement']->getAbsoluteOffset($this->getDefinition()->getDataOffset())));

--- a/src/Block/Exif/Ifd.php
+++ b/src/Block/Exif/Ifd.php
@@ -98,6 +98,13 @@ class Ifd extends ListBase
     }
 
     /**
+     * @todo remove, replace by parser
+     */
+    protected function doParseData(DataElement $data): void
+    {
+    }
+
+    /**
      * Gets the number of items in the IFD, from the data.
      *
      * Items can be TAGs, other IFDs, etc.

--- a/src/Block/Exif/Vendor/Apple/RunTime.php
+++ b/src/Block/Exif/Vendor/Apple/RunTime.php
@@ -21,6 +21,8 @@ class RunTime extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
+
         $plist = new CFPropertyList();
         $plist->parse($data->getBytes(0, $this->getDefinition()->getValuesCount()));
 

--- a/src/Block/Exif/Vendor/Canon/AFInfoIndex.php
+++ b/src/Block/Exif/Vendor/Canon/AFInfoIndex.php
@@ -27,7 +27,7 @@ class AFInfoIndex extends Index
         // by opening a 'rawData' node instead of a 'tag'.
         $offset = 0;
         $this->components = $this->getDefinition()->getValuesCount();
-        assert($this->debugInfo(['dataElement' => $data]);
+        assert($this->debugInfo(['dataElement' => $data]));
 
         for ($i = 0; $i < $this->components; $i++) {
             $item_definition = $this->getItemDefinitionFromData($i, $i, $data, $offset);

--- a/src/Block/Exif/Vendor/Canon/AFInfoIndex.php
+++ b/src/Block/Exif/Vendor/Canon/AFInfoIndex.php
@@ -21,6 +21,7 @@ class AFInfoIndex extends Index
     protected function doParseData(DataElement $data): void
     {
         $this->validate($data);
+        assert($this->debugInfo(['dataElement' => $data]));
 
         // Loops through the index and loads the tags. If the 'hasIndexSize'
         // property is true, the first entry is a special case that is handled

--- a/src/Block/Exif/Vendor/Canon/AFInfoIndex.php
+++ b/src/Block/Exif/Vendor/Canon/AFInfoIndex.php
@@ -21,16 +21,15 @@ class AFInfoIndex extends Index
     protected function doParseData(DataElement $data): void
     {
         $this->validate($data);
-        assert($this->debugInfo(['dataElement' => $data]));
 
         // Loops through the index and loads the tags. If the 'hasIndexSize'
         // property is true, the first entry is a special case that is handled
         // by opening a 'rawData' node instead of a 'tag'.
         $offset = 0;
-        $index_components = $this->getDefinition()->getValuesCount();
-        assert($this->debugInfo(['dataElement' => $data, 'itemsCount' => $index_components]));
+        $this->components = $this->getDefinition()->getValuesCount();
+        assert($this->debugInfo(['dataElement' => $data]);
 
-        for ($i = 0; $i < $index_components; $i++) {
+        for ($i = 0; $i < $this->components; $i++) {
             $item_definition = $this->getItemDefinitionFromData($i, $i, $data, $offset);
 
             // Check if this tag should be skipped.
@@ -41,10 +40,10 @@ class AFInfoIndex extends Index
 
             if (in_array($item_definition->getCollection()->getPropertyValue('name'), ['AFAreaWidths', 'AFAreaHeights', 'AFAreaXPositions', 'AFAreaYPositions'])) {
                 $value_components = $this->getElement("tag[@name='NumAFPoints']")->getElement("entry")->getValue();
-                $index_components -= ($value_components - 1);
+                $this->components -= ($value_components - 1);
             } elseif (in_array($item_definition->getCollection()->getPropertyValue('name'), ['AFPointsInFocus', 'AFPointsSelected'])) {
                 $value_components = (int) (($this->getElement("tag[@name='NumAFPoints']")->getElement("entry")->getValue() + 15) / 16);
-                $index_components -= ($value_components - 1);
+                $this->components -= ($value_components - 1);
             } else {
                 $value_components = 1;
             }

--- a/src/Block/Exif/Vendor/Canon/CustomFunctions2.php
+++ b/src/Block/Exif/Vendor/Canon/CustomFunctions2.php
@@ -25,6 +25,8 @@ class CustomFunctions2 extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
+
         $rec_pos = 0;
         for ($n = 0; $n < $this->getDefinition()->getValuesCount(); $n++) {
             $id = $data->getLong($rec_pos);

--- a/src/Block/Exif/Vendor/Canon/CustomFunctions2Header.php
+++ b/src/Block/Exif/Vendor/Canon/CustomFunctions2Header.php
@@ -26,6 +26,8 @@ class CustomFunctions2Header extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
+
         $offset = 0;
         $size = $this->getDefinition()->getSize();
 

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -96,7 +96,6 @@ class Filter extends ListBase
             '_msg' =>'filter#{seq} @{offset}, {parms} parameter(s), size {size} bytes',
             'seq' => $this->getDefinition()->getSequence() + 1,
             'parms' => $this->paramsCount ?? 'n/a',
-            'size' => $this->getDefinition()->getSize(),
         ]);
     }
 

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -35,8 +35,6 @@ class Filter extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
-        assert($this->debugInfo(['dataElement' => $data]));
-
         $offset = 0;
 
         // The id of the filter is at offset 0.
@@ -45,6 +43,8 @@ class Filter extends ListBase
         // The count of filter parameters is at offset 8.
         $this->paramsCount = $data->getLong($offset + 8);
         $offset += 12;
+
+        assert($this->debugInfo(['dataElement' => $data]));
 
         // Loop and parse through the parameters.
         for ($p = 0; $p < $this->paramsCount; $p++) {
@@ -59,10 +59,14 @@ class Filter extends ListBase
                     DataFormat::SIGNED_LONG,
                     $val_count,
                     0,
-                    999,
+                    $offset,
                     $p,
                 ))
-                ->parseData(new DataWindow($data, $offset, $val_count * DataFormat::getSize(DataFormat::SIGNED_LONG)));
+                ->parseData(new DataWindow(
+                    $data,
+                    $offset,
+                    $val_count * DataFormat::getSize(DataFormat::SIGNED_LONG)
+                ));
 
             $offset += 4 * $val_count;
         }
@@ -102,9 +106,9 @@ class Filter extends ListBase
     public function collectInfo(array $context = []): array
     {
         return array_merge(parent::collectInfo($context), [
-            '_msg' =>'filter#{seq} @{offset}, {parms} parameter(s), size {size} bytes',
+//            '_msg' =>'filter#{seq} @{offset}, {parmetersCount} parameter(s), size {size} bytes',
             'seq' => $this->getDefinition()->getSequence() + 1,
-            'parms' => $this->paramsCount ?? 'n/a',
+            'parmetersCount' => $this->paramsCount,
         ]);
     }
 

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -106,7 +106,7 @@ class Filter extends ListBase
     public function collectInfo(array $context = []): array
     {
         return array_merge(parent::collectInfo($context), [
-//            '_msg' =>'filter#{seq} @{offset}, {parmetersCount} parameter(s), size {size} bytes',
+            '_msg' =>'#{seq}.{name}.filter @{offset}, {parmetersCount} parameter(s), size {size} bytes',
             'seq' => $this->getDefinition()->getSequence() + 1,
             'parmetersCount' => $this->paramsCount,
         ]);

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -35,7 +35,7 @@ class Filter extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
-dump([$this, $this->getParentElement()]);
+dump([$this->getAttribute('name'), $this->getParentElement()->getAttribute('name'), $this->getParentElement()->getParentElement()->getAttribute('name')]);
         $offset = 0;
 
         // The id of the filter is at offset 0.

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -35,6 +35,8 @@ class Filter extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
+
         $offset = 0;
 
         // The id of the filter is at offset 0.

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -42,7 +42,6 @@ class Filter extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
-//dump([$this->getAttribute('name'), $this->getParentElement()->getAttribute('name'), $this->getParentElement()->getParentElement()->getAttribute('name')]);
         $offset = 0;
 
         // The id of the filter is at offset 0.
@@ -88,7 +87,7 @@ class Filter extends ListBase
         $bytes = '';
 
         // The id of the filter.
-        $bytes .= ConvertBytes::fromLong($this->getAttribute('id'), $byte_order);
+        $bytes .= ConvertBytes::fromLong((int) $this->getAttribute('id'), $byte_order);
 
         // Build the parameters.
         $params = $this->getMultipleElements('*');

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -56,14 +56,14 @@ class Filter extends ListBase
 
         // Loop and parse through the parameters.
         for ($p = 0; $p < $this->paramsCount; $p++) {
-            $id = $data->getLong($offset);
+            $id = (string) $data->getLong($offset);
             $val_count = $data->getLong($offset + 4);
             $offset += 8;
 
             // The items are defined in the collection of the parent element.
             $this
                 ->addBlock(new ItemDefinition(
-                    (string) $this->getParentElement()->getCollection()->getItemCollection($id),
+                    $this->getParentElement()->getCollection()->getItemCollection($id),
                     DataFormat::SIGNED_LONG,
                     $val_count,
                     0,

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -93,7 +93,7 @@ class Filter extends ListBase
         $params = $this->getMultipleElements('*');
         $data_area_bytes = '';
         foreach ($params as $param) {
-            $data_area_bytes .= ConvertBytes::fromLong($param->getAttribute('id'), $byte_order);
+            $data_area_bytes .= ConvertBytes::fromLong((int)  $param->getAttribute('id'), $byte_order);
             $data_area_bytes .= ConvertBytes::fromLong($param->getComponents(), $byte_order);
             $data_area_bytes .= $param->toBytes($byte_order);
         }

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -30,12 +30,18 @@ class Filter extends ListBase
      */
     protected int $paramsCount;
 
+    public function __construct(ItemDefinition $definition, BlockInterface $parent = null, BlockInterface $reference = null)
+    {
+dump($definition);
+        parent::__construct($definition, $parent, $reference);
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function doParseData(DataElement $data): void
     {
-dump([$this->getAttribute('name'), $this->getParentElement()->getAttribute('name'), $this->getParentElement()->getParentElement()->getAttribute('name')]);
+//dump([$this->getAttribute('name'), $this->getParentElement()->getAttribute('name'), $this->getParentElement()->getParentElement()->getAttribute('name')]);
         $offset = 0;
 
         // The id of the filter is at offset 0.

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -33,8 +33,8 @@ class Filter extends ListBase
 
     public function __construct(ItemDefinition $definition, BlockInterface $parent = null, BlockInterface $reference = null)
     {
-dump($definition);
         parent::__construct($definition, $parent, $reference);
+        $this->setAttribute('name', $this->getParentElement()->getAttribute('name') . '.' . $definition->getSequence());
     }
 
     /**
@@ -46,7 +46,7 @@ dump($definition);
         $offset = 0;
 
         // The id of the filter is at offset 0.
-        $this->setAttribute('id', $data->getLong($offset));
+        $this->setAttribute('id', (string) $data->getLong($offset));
 
         // The count of filter parameters is at offset 8.
         $this->paramsCount = $data->getLong($offset + 8);
@@ -114,7 +114,7 @@ dump($definition);
     public function collectInfo(array $context = []): array
     {
         return array_merge(parent::collectInfo($context), [
-            '_msg' =>'{node}.{name}#{seq} @{offset}, {parmetersCount} parameter(s), size {size} bytes',
+            '_msg' =>'#{seq}.{node}.{name} @{offset}, {parmetersCount} parameter(s), size {size} bytes',
             'seq' => $this->getDefinition()->getSequence() + 1,
             'parmetersCount' => $this->paramsCount,
         ]);

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -1,18 +1,19 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace FileEye\MediaProbe\Block\Exif\Vendor\Canon;
 
-use FileEye\MediaProbe\Block\ListBase;
 use FileEye\MediaProbe\Block\Index;
+use FileEye\MediaProbe\Block\ListBase;
 use FileEye\MediaProbe\Block\Map;
 use FileEye\MediaProbe\Block\RawData;
 use FileEye\MediaProbe\Block\Tag;
 use FileEye\MediaProbe\Data\DataElement;
+use FileEye\MediaProbe\Data\DataFormat;
 use FileEye\MediaProbe\Data\DataWindow;
 use FileEye\MediaProbe\ItemDefinition;
-use FileEye\MediaProbe\Data\DataFormat;
 use FileEye\MediaProbe\MediaProbe;
 use FileEye\MediaProbe\MediaProbeException;
+use FileEye\MediaProbe\Model\BlockInterface;
 use FileEye\MediaProbe\Utility\ConvertBytes;
 
 /**

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -63,7 +63,7 @@ class Filter extends ListBase
             // The items are defined in the collection of the parent element.
             $this
                 ->addBlock(new ItemDefinition(
-                    $this->getParentElement()->getCollection()->getItemCollection($id),
+                    (string) $this->getParentElement()->getCollection()->getItemCollection($id),
                     DataFormat::SIGNED_LONG,
                     $val_count,
                     0,
@@ -114,7 +114,7 @@ class Filter extends ListBase
     public function collectInfo(array $context = []): array
     {
         return array_merge(parent::collectInfo($context), [
-            '_msg' =>'#{seq}.{node}.{name} @{offset}, {parmetersCount} parameter(s), size {size} bytes',
+            '_msg' =>'#{seq}.{name} @{offset}, {parmetersCount} parameter(s), size {size} bytes',
             'seq' => $this->getDefinition()->getSequence() + 1,
             'parmetersCount' => $this->paramsCount,
         ]);

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -54,7 +54,14 @@ class Filter extends ListBase
 
             // The items are defined in the collection of the parent element.
             $this
-                ->addBlock(new ItemDefinition($this->getParentElement()->getCollection()->getItemCollection($id), DataFormat::SIGNED_LONG, $val_count))
+                ->addBlock(new ItemDefinition(
+                    $this->getParentElement()->getCollection()->getItemCollection($id),
+                    DataFormat::SIGNED_LONG,
+                    $val_count,
+                    0,
+                    999,
+                    $p,
+                ))
                 ->parseData(new DataWindow($data, $offset, $val_count * DataFormat::getSize(DataFormat::SIGNED_LONG)));
 
             $offset += 4 * $val_count;

--- a/src/Block/Exif/Vendor/Canon/Filter.php
+++ b/src/Block/Exif/Vendor/Canon/Filter.php
@@ -35,6 +35,7 @@ class Filter extends ListBase
      */
     protected function doParseData(DataElement $data): void
     {
+dump([$this, $this->getParentElement()]);
         $offset = 0;
 
         // The id of the filter is at offset 0.
@@ -106,7 +107,7 @@ class Filter extends ListBase
     public function collectInfo(array $context = []): array
     {
         return array_merge(parent::collectInfo($context), [
-            '_msg' =>'#{seq}.{name}.filter @{offset}, {parmetersCount} parameter(s), size {size} bytes',
+            '_msg' =>'{node}.{name}#{seq} @{offset}, {parmetersCount} parameter(s), size {size} bytes',
             'seq' => $this->getDefinition()->getSequence() + 1,
             'parmetersCount' => $this->paramsCount,
         ]);

--- a/src/Block/Exif/Vendor/Canon/FilterInfoIndex.php
+++ b/src/Block/Exif/Vendor/Canon/FilterInfoIndex.php
@@ -35,11 +35,6 @@ use FileEye\MediaProbe\Utility\ConvertBytes;
 class FilterInfoIndex extends Index
 {
     /**
-     * The count of filters.
-     */
-    protected int $indexComponents;
-
-    /**
      * {@inheritdoc}
      */
     protected function doParseData(DataElement $data): void
@@ -47,7 +42,7 @@ class FilterInfoIndex extends Index
         $offset = 0;
 
         // The count of filters is at offset 4.
-        $this->indexComponents = $data->getLong($offset + 4);
+        $this->components = $data->getLong($offset + 4);
 
         assert($this->debugInfo(['dataElement' => $data]));
 
@@ -58,7 +53,7 @@ class FilterInfoIndex extends Index
         $offset += 8;
 
         // Loop and parse through the filters.
-        for ($i = 0; $i < $this->indexComponents; $i++) {
+        for ($i = 0; $i < $this->components; $i++) {
             $filter_size = $data->getLong($offset + 4);
             $this
                 ->addBlock(
@@ -113,7 +108,7 @@ class FilterInfoIndex extends Index
     {
         $info = [];
         $parentInfo = parent::collectInfo($context);
-        $info['tags'] = $this->indexComponents;
+        $info['tags'] = $this->components;
         return array_merge($parentInfo, $info);
     }
 }

--- a/src/Block/Exif/Vendor/Canon/FilterInfoIndex.php
+++ b/src/Block/Exif/Vendor/Canon/FilterInfoIndex.php
@@ -60,7 +60,14 @@ class FilterInfoIndex extends Index
         for ($i = 0; $i < $index_components; $i++) {
             $filter_size = $data->getLong($offset + 4);
             $this
-                ->addBlock(new ItemDefinition(CollectionFactory::get('ExifMakerNotes\Canon\Filter'), DataFormat::BYTE, $filter_size, $offset, 0, $i))
+                ->addBlock(
+                    new ItemDefinition(CollectionFactory::get('ExifMakerNotes\Canon\Filter'),
+                    DataFormat::BYTE,
+                    $filter_size,
+                    $offset,
+                    0,
+                    $i
+                ))
                 ->parseData(new DataWindow($data, $offset, $filter_size + 4));
             $offset += 4 + $filter_size;
         }

--- a/src/Block/Exif/Vendor/Canon/FilterInfoIndex.php
+++ b/src/Block/Exif/Vendor/Canon/FilterInfoIndex.php
@@ -39,6 +39,8 @@ class FilterInfoIndex extends Index
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
+
         $offset = 0;
 
         // The first 4 bytes is a marker (?), store as RawData.

--- a/src/Block/Index.php
+++ b/src/Block/Index.php
@@ -219,11 +219,10 @@ class Index extends ListBase
             $info['seq'] = $parent_name . '.' . $info['seq'];
         }
 
-        $item = $this->getAttribute('id');
-        if ($item ==! null) {
+        if (isset($parentInfo['item'])) {
             $msg .= ' ({item})';
+            $info['item'] = is_numeric($item) ?$info['item'] . '/0x' . strtoupper(dechex($info['item'])) : $info['item'];
         }
-        $info['item'] = is_numeric($item) ? $item . '/0x' . strtoupper(dechex($item)) : $item;
 
         if (isset($parentInfo['size'])) {
             $msg .= isset($parentInfo['offset']) ? ' @{offset}, {tags} entries, f {format}, s {size}' : ' {tags} entries, format ?xxx, size {size}';

--- a/src/Block/Index.php
+++ b/src/Block/Index.php
@@ -221,7 +221,7 @@ class Index extends ListBase
 
         if (isset($parentInfo['item'])) {
             $msg .= ' ({item})';
-            $info['item'] = is_numeric($item) ?$info['item'] . '/0x' . strtoupper(dechex($info['item'])) : $info['item'];
+            $info['item'] = is_numeric($parentInfo['item']) ?$parentInfo['item'] . '/0x' . strtoupper(dechex($parentInfo['item'])) : $parentInfo['item'];
         }
 
         if (isset($parentInfo['size'])) {

--- a/src/Block/Index.php
+++ b/src/Block/Index.php
@@ -50,6 +50,7 @@ class Index extends ListBase
     protected function doParseData(DataElement $data): void
     {
         $this->validate($data);
+        assert($this->debugInfo(['dataElement' => $data]));
 
         // Loop through the index and parse the tags. If the 'hasIndexSize'
         // property is true, the first entry is a special case that is handled

--- a/src/Block/Index.php
+++ b/src/Block/Index.php
@@ -50,16 +50,15 @@ class Index extends ListBase
     protected function doParseData(DataElement $data): void
     {
         $this->validate($data);
-        assert($this->debugInfo(['dataElement' => $data]));
 
         // Loop through the index and parse the tags. If the 'hasIndexSize'
         // property is true, the first entry is a special case that is handled
         // by opening a 'rawData' node instead of a 'tag'.
         $offset = 0;
-        $index_components = $this->getDefinition()->getValuesCount();
-        assert($this->debugInfo(['dataElement' => $data, 'itemsCount' => $index_components]));
+        $this->components = $this->getDefinition()->getValuesCount();
+        assert($this->debugInfo(['dataElement' => $data]));
 
-        for ($i = 0; $i < $index_components; $i++) {
+        for ($i = 0; $i < $this->components; $i++) {
             $item_definition = $this->getItemDefinitionFromData($i, $i, $data, $offset);
 
             // Check if this tag should be skipped.
@@ -68,7 +67,7 @@ class Index extends ListBase
                 continue;
             };
 
-            $index_components -= ($item_definition->getValuesCount() - 1);
+            $this->components -= ($item_definition->getValuesCount() - 1);
 
             // Adds the 'tag'.
             $this->addBlock($item_definition)->parseData($data, $item_definition->getDataOffset(), $item_definition->getSize());

--- a/src/Block/Jpeg.php
+++ b/src/Block/Jpeg.php
@@ -33,6 +33,8 @@ class Jpeg extends BlockBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
+
         // JPEG data is stored in big-endian format.
         $data->setByteOrder(ConvertBytes::BIG_ENDIAN);
 

--- a/src/Block/JpegSegment.php
+++ b/src/Block/JpegSegment.php
@@ -18,6 +18,7 @@ class JpegSegment extends JpegSegmentBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         // Adds the segment data as an Undefined entry.
         new Undefined($this, $data);
     }

--- a/src/Block/JpegSegmentApp1.php
+++ b/src/Block/JpegSegmentApp1.php
@@ -21,6 +21,7 @@ class JpegSegmentApp1 extends JpegSegmentBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         // If we have an Exif table, parse it.
         if (Exif::isExifSegment($data, 4)) {
             $exif = new ItemDefinition(CollectionFactory::get('Exif\Exif'));

--- a/src/Block/JpegSegmentCom.php
+++ b/src/Block/JpegSegmentCom.php
@@ -17,6 +17,7 @@ class JpegSegmentCom extends JpegSegmentBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         // Adds the segment data as a Char string.
         new Char($this, new DataWindow($data, 4));
     }

--- a/src/Block/JpegSegmentSos.php
+++ b/src/Block/JpegSegmentSos.php
@@ -25,6 +25,7 @@ class JpegSegmentSos extends JpegSegmentBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         // This segment is last before End Of Image, and its length needs to be
         // determined by finding the EOI marker backwards from the end of data.
         // Some images have some trailing (garbage?) following the EOI marker,

--- a/src/Block/ListBase.php
+++ b/src/Block/ListBase.php
@@ -26,6 +26,11 @@ use FileEye\MediaProbe\Utility\ConvertBytes;
 abstract class ListBase extends BlockBase
 {
     /**
+     * The amount of components in the list.
+     */
+    protected int $components;
+
+    /**
      * {@inheritdoc}
      */
     public function getComponents(): int

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -47,6 +47,7 @@ class Map extends Index
     protected function doParseData(DataElement $data): void
     {
         $this->validate($data);
+        assert($this->debugInfo(['dataElement' => $data]));
 
         // Preserve the entire map as a raw data block.
         $mapdata = new ItemDefinition(CollectionFactory::get('RawData', ['name' => 'mapdata']));

--- a/src/Block/Map.php
+++ b/src/Block/Map.php
@@ -27,11 +27,6 @@ class Map extends Index
     protected int $format;
 
     /**
-     * The amount of components in the map.
-     */
-    protected int $components;
-
-    /**
      * {@inheritdoc}
      */
     public function __construct(ItemDefinition $definition, BlockBase $parent = null, BlockBase $reference = null)

--- a/src/Block/RawData.php
+++ b/src/Block/RawData.php
@@ -43,6 +43,7 @@ class RawData extends BlockBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         new Undefined($this, $data);
     }
 

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -152,7 +152,7 @@ class Tag extends BlockBase
 
         if (isset($parentInfo['item'])) {
             $msg .= ' ({item})';
-            $info['item'] = MediaProbe::dumpIntHex($info['item']);
+            $info['item'] = MediaProbe::dumpIntHex($parentInfo['item']);
         }
 
         if (isset($parentInfo['size'])) {

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -150,11 +150,10 @@ class Tag extends BlockBase
 
         $msg .= isset($parentInfo['name']) ? ':{name}' : '';
 
-        $item = $this->getAttribute('id');
-        if ($item ==! null) {
+        if (isset($parentInfo['item'])) {
             $msg .= ' ({item})';
+            $info['item'] = MediaProbe::dumpIntHex($info['item']);
         }
-        $info['item'] = MediaProbe::dumpIntHex($item);
 
         if (isset($parentInfo['size'])) {
             $msg .= isset($parentInfo['offset']) ? ' @{offset} size {size}' : ' size {size} byte(s)';

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -19,15 +19,6 @@ use FileEye\MediaProbe\Utility\ConvertBytes;
 class Tag extends BlockBase
 {
     /**
-     * Constructs a Tag block object.
-     */
-    public function __construct(ItemDefinition $definition, BlockBase $parent = null, ElementInterface $reference = null)
-    {
-        parent::__construct($definition, $parent, $reference);
-        $this->validate();
-    }
-
-    /**
      * Validates against the specification, if defined.
      */
     public function validate(): void
@@ -73,6 +64,7 @@ class Tag extends BlockBase
      */
     protected function doParseData(DataElement $data): void
     {
+        $this->validate();
         assert($this->debugInfo(['dataElement' => $data]));
         try {
             $class = $this->getDefinition()->getEntryClass();
@@ -148,7 +140,7 @@ class Tag extends BlockBase
             $info['seq'] = $parent_name . '.' . $info['seq'];
         }
 
-dump($this->getDefinition());
+//dump($this->getDefinition());
         $info['relativeOffset'] = MediaProbe::dumpIntHex($this->getDefinition()->getItemDefinitionOffset());
 
         $msg .= isset($parentInfo['name']) ? ':{name}' : '';

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -140,7 +140,6 @@ class Tag extends BlockBase
             $info['seq'] = $parent_name . '.' . $info['seq'];
         }
 
-//dump($this->getDefinition());
         $info['relativeOffset'] = MediaProbe::dumpIntHex($this->getDefinition()->getItemDefinitionOffset());
 
         $msg .= isset($parentInfo['name']) ? ':{name}' : '';

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -73,6 +73,7 @@ class Tag extends BlockBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         try {
             $class = $this->getDefinition()->getEntryClass();
             $entry = new $class($this, $data);
@@ -140,7 +141,7 @@ class Tag extends BlockBase
 
         $parentInfo = parent::collectInfo($context);
 
-        $msg = '#{seq} @{ifdoffset} {node}';
+        $msg = '#{seq} ifd@{ifdoffset} {node}';
 
         $info['seq'] = $this->getDefinition()->getSequence() + 1;
         if ($this->getParentElement() && ($parent_name = $this->getParentElement()->getAttribute('name'))) {
@@ -161,7 +162,7 @@ class Tag extends BlockBase
 
         $info['format'] = DataFormat::getName($this->getDefinition()->getFormat());
         $info['components'] = $this->getDefinition()->getValuesCount();
-        $msg .= ', format {format}, components {components}';
+        $msg .= ' format {format} count {components}';
 
         $info['_msg'] = $msg;
 

--- a/src/Block/Tag.php
+++ b/src/Block/Tag.php
@@ -141,13 +141,15 @@ class Tag extends BlockBase
 
         $parentInfo = parent::collectInfo($context);
 
-        $msg = '#{seq} ifd@{ifdoffset} {node}';
+        $msg = '#{seq} rel@{relativeOffset} {node}';
 
         $info['seq'] = $this->getDefinition()->getSequence() + 1;
         if ($this->getParentElement() && ($parent_name = $this->getParentElement()->getAttribute('name'))) {
             $info['seq'] = $parent_name . '.' . $info['seq'];
         }
-        $info['ifdoffset'] = MediaProbe::dumpIntHex($this->getDefinition()->getItemDefinitionOffset());
+
+dump($this->getDefinition());
+        $info['relativeOffset'] = MediaProbe::dumpIntHex($this->getDefinition()->getItemDefinitionOffset());
 
         $msg .= isset($parentInfo['name']) ? ':{name}' : '';
 

--- a/src/Block/Thumbnail.php
+++ b/src/Block/Thumbnail.php
@@ -16,6 +16,7 @@ class Thumbnail extends BlockBase
      */
     protected function doParseData(DataElement $data): void
     {
+        assert($this->debugInfo(['dataElement' => $data]));
         // Adds the segment data as an Undefined entry.
         new Undefined($this, $data);
     }

--- a/src/Block/Tiff.php
+++ b/src/Block/Tiff.php
@@ -56,16 +56,16 @@ class Tiff extends BlockBase
     /**
      * {@inheritdoc}
      */
-    protected function doParseData(DataElement $data_element): void
+    protected function doParseData(DataElement $data): void
     {
         // Determine the byte order of the TIFF data.
-        $this->setByteOrder(self::getTiffSegmentByteOrder($data_element));
-        $data_element->setByteOrder($this->getByteOrder());
+        $this->setByteOrder(self::getTiffSegmentByteOrder($data));
+        $data->setByteOrder($this->getByteOrder());
 
         assert($this->debugInfo(['dataElement' => $data]));
 
         // Starting IFD will be at offset 4 (2 bytes for byte order + 2 for header).
-        $ifd_offset = $data_element->getLong(4);
+        $ifd_offset = $data->getLong(4);
 
         // If the offset to first IFD is higher than 8, then there may be an
         // image scan (TIFF) in between. Store that in a RawData block.
@@ -75,13 +75,13 @@ class Tiff extends BlockBase
                 DataFormat::BYTE,
                 $ifd_offset - 8
             );
-            $this->addBlock($scan)->parseData($data_element, 8, $ifd_offset - 8);
+            $this->addBlock($scan)->parseData($data, 8, $ifd_offset - 8);
         }
 
         // Loops through IFDs. In fact we should only have IFD0 and IFD1.
         for ($i = 0; $i <= 1; $i++) {
             // Check data is accessible, warn otherwise.
-            if ($ifd_offset >= $data_element->getSize() || $ifd_offset + 4 > $data_element->getSize()) {
+            if ($ifd_offset >= $data->getSize() || $ifd_offset + 4 > $data->getSize()) {
                 $this->warning(
                     'Could not determine number of entries for {item}, overflow',
                     ['item' => $this->getCollection()->getItemCollection($i)->getPropertyValue('name')]
@@ -90,8 +90,8 @@ class Tiff extends BlockBase
             }
 
             // Find number of tags in IFD and warn if not enough data to read them.
-            $ifd_tags_count = $data_element->getShort($ifd_offset);
-            if ($ifd_offset + $ifd_tags_count * 4 > $data_element->getSize()) {
+            $ifd_tags_count = $data->getShort($ifd_offset);
+            if ($ifd_offset + $ifd_tags_count * 4 > $data->getSize()) {
                 $this->warning(
                     'Invalid data for {item}',
                     ['item' => $this->getCollection()->getItemCollection($i)->getPropertyValue('name')]
@@ -106,7 +106,7 @@ class Tiff extends BlockBase
             $ifd_item = new ItemDefinition($this->getCollection()->getItemCollection($i), DataFormat::LONG, $ifd_tags_count, $ifd_offset, 0, $i);
             $ifd = new $ifd_class($ifd_item, $this);
             try {
-                $ifd->parseData($data_element);
+                $ifd->parseData($data);
             } catch (DataException $e) {
                 $this->error('Error processing {ifd_name}: {msg}.', [
                     'ifd_name' => $this->getCollection()->getItemCollection($i)->getPropertyValue('name'),
@@ -116,7 +116,7 @@ class Tiff extends BlockBase
             }
 
             // Offset to next IFD.
-            $ifd_offset = $data_element->getLong($ifd_offset + $ifd_tags_count * 12 + 2);
+            $ifd_offset = $data->getLong($ifd_offset + $ifd_tags_count * 12 + 2);
 
             // If next IFD offset is 0 we are finished.
             if ($ifd_offset === 0) {

--- a/src/Block/Tiff.php
+++ b/src/Block/Tiff.php
@@ -62,10 +62,7 @@ class Tiff extends BlockBase
         $this->setByteOrder(self::getTiffSegmentByteOrder($data_element));
         $data_element->setByteOrder($this->getByteOrder());
 
-        $this->debug('byte order: {byte_order} ({byte_order_description})', [
-            'byte_order' => $this->getByteOrder() === ConvertBytes::LITTLE_ENDIAN ? 'II' : 'MM',
-            'byte_order_description' => $this->getByteOrder() === ConvertBytes::LITTLE_ENDIAN ? 'Little Endian' : 'Big Endian',
-        ]);
+        assert($this->debugInfo(['dataElement' => $data]));
 
         // Starting IFD will be at offset 4 (2 bytes for byte order + 2 for header).
         $ifd_offset = $data_element->getLong(4);
@@ -230,5 +227,18 @@ class Tiff extends BlockBase
         }
 
         return $order;
+    }
+
+    public function collectInfo(array $context = []): array
+    {
+        $info = [];
+
+        $parentInfo = parent::collectInfo($context);
+
+        $info['_msg'] = $parentInfo['_msg'] . ' byte order {byteOrder} ({byteOrderDescription})';
+        $info['byteOrder'] = $this->getByteOrder() === ConvertBytes::LITTLE_ENDIAN ? 'II' : 'MM';
+        $info['byteOrderDescription'] = $this->getByteOrder() === ConvertBytes::LITTLE_ENDIAN ? 'Little Endian' : 'Big Endian';
+
+        return array_merge($parentInfo, $info);
     }
 }

--- a/src/Collection/ExifMakerNotes/Canon/FilterInfo.php
+++ b/src/Collection/ExifMakerNotes/Canon/FilterInfo.php
@@ -16,7 +16,7 @@ class FilterInfo extends CollectionBase {
   'name' => 'CanonFilterInfo',
   'title' => 'Canon FilterInfo',
   'class' => 'FileEye\\MediaProbe\\Block\\Exif\\Vendor\\Canon\\FilterInfoIndex',
-  'DOMNode' => 'index',
+  'DOMNode' => 'filterInfo',
   'defaultItemCollection' => 'Tag',
   'id' => 'ExifMakerNotes\\Canon\\FilterInfo',
   'itemsByName' =>

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -37,7 +37,7 @@ class CompileCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $compiler = new SpecCompiler();
         $compiler->compile($input->getArgument('spec-dir'), $input->getArgument('resource-dir'));

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -56,7 +56,7 @@ class DumpCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $sourcePath = $input->getArgument('file-path');
         $dumpPath = $input->getArgument('dump-path');

--- a/src/Command/ExifToolResourceUpdateCommand.php
+++ b/src/Command/ExifToolResourceUpdateCommand.php
@@ -39,7 +39,7 @@ class ExifToolResourceUpdateCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $filesystem = new Filesystem();
 

--- a/src/Media.php
+++ b/src/Media.php
@@ -107,6 +107,13 @@ class Media extends RootBlockBase
     }
 
     /**
+     * @todo remove, replace by parser
+     */
+    protected function doParseData(DataElement $data): void
+    {
+    }
+
+    /**
      * Determines the media format collection of the media data.
      *
      * @param DataElement $data_element

--- a/src/Model/BlockBase.php
+++ b/src/Model/BlockBase.php
@@ -105,7 +105,6 @@ abstract class BlockBase extends ElementBase implements BlockInterface
     {
         $data = new DataWindow($data_element, $start, $size);
         $this->size = $data->getSize();
-        assert($this->debugInfo(['dataElement' => $data]));
         $this->doParseData($data);
 
         // Invoke post-parse callbacks.

--- a/src/Model/BlockBase.php
+++ b/src/Model/BlockBase.php
@@ -180,12 +180,13 @@ abstract class BlockBase extends ElementBase implements BlockInterface
     {
         $info = [];
 
-        $msg = '{node}';
+        $parentInfo = parent::collectInfo($context);
 
-        if (($name = $this->getAttribute('name')) ==! null) {
-            $info['name'] = $name;
+        $msg = '{node}';
+        if (isset($parentInfo['name'])) {
             $msg .= ':{name}';
         }
+
         if (($title = $this->getCollection()->getPropertyValue('title')) ==! null) {
             $info['title'] = $title;
             $msg .= ' ({title})';
@@ -196,7 +197,7 @@ abstract class BlockBase extends ElementBase implements BlockInterface
             if ($context['dataElement'] instanceof DataWindow) {
                 $msg .= ' @{offset} size {size}';
                 $info['offset'] = $context['dataElement']->getAbsoluteOffset() . '/0x' . strtoupper(dechex($context['dataElement']->getAbsoluteOffset()));
-// @todo $offset = MediaProbe::dumpIntHex($context['dataElement']->getAbsoluteOffset());
+                // @todo $offset = MediaProbe::dumpIntHex($context['dataElement']->getAbsoluteOffset());
             } else {
                 $msg .= ' size {size} byte(s)';
             }

--- a/src/Model/BlockBase.php
+++ b/src/Model/BlockBase.php
@@ -117,10 +117,7 @@ abstract class BlockBase extends ElementBase implements BlockInterface
      * @param DataElement $data_element
      *   The data element that will provide the data.
      */
-    protected function doParseData(DataElement $data): void
-    {
-        throw new MediaProbeException("%s does not implement the %s method.", get_called_class(), __FUNCTION__);
-    }
+    abstract protected function doParseData(DataElement $data);
 
     /**
      * Invoke post-parse callbacks.

--- a/src/Model/BlockBase.php
+++ b/src/Model/BlockBase.php
@@ -204,6 +204,6 @@ abstract class BlockBase extends ElementBase implements BlockInterface
 
         $info['_msg'] = $msg;
 
-        return array_merge(parent::collectInfo($context), $info);
+        return array_merge($parentInfo, $info);
     }
 }

--- a/src/Model/ElementBase.php
+++ b/src/Model/ElementBase.php
@@ -193,7 +193,7 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
 
     public function collectInfo(array $context = []): array
     {
-        $info = [};
+        $info = [];
         $info['node'] = $this->getNodeName();
         if (($name = $this->getAttribute('name')) !== null) {
             $info['name'] = $name;

--- a/src/Model/ElementBase.php
+++ b/src/Model/ElementBase.php
@@ -81,9 +81,6 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         return $this->DOMNode->getMediaProbeElement() !== $this->getRootElement() ? $this->DOMNode->parentNode->getMediaProbeElement() : null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getMultipleElements(string $expression): array
     {
         $node_list = $this->getRootElement()->XPath->query($expression, $this->DOMNode);
@@ -94,9 +91,6 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         return $ret;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getElement(string $expression): ?ElementInterface
     {
         $ret = $this->getMultipleElements($expression);
@@ -110,9 +104,6 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function removeElement(string $expression): bool
     {
         $ret = $this->getMultipleElements($expression);
@@ -127,17 +118,11 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setAttribute(string $name, string $value): \DOMAttr|bool
     {
         return $this->DOMNode->setAttribute($name, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAttributes(): array
     {
         $attr = [];
@@ -147,9 +132,6 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         return $attr;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAttribute(string $name): string
     {
         return $this->DOMNode->getAttribute($name);
@@ -163,9 +145,6 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         return '/{DOMNode}';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getContextPath(): string
     {
         // Get the path before this element.
@@ -182,9 +161,6 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         return $parent_path . str_replace(array_keys($attributes), array_values($attributes), $this->getContextPathSegmentPattern());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isValid(): bool
     {
         return $this->valid;
@@ -198,17 +174,11 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         throw new MediaProbeException("%s does not implement the %s method.", static::class, __FUNCTION__);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getValue(array $options = []): mixed
     {
         throw new MediaProbeException("%s does not implement the %s method.", static::class, __FUNCTION__);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toString(array $options = []): string
     {
         throw new MediaProbeException("%s does not implement the %s method.", static::class, __FUNCTION__);
@@ -223,9 +193,15 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
 
     public function collectInfo(array $context = []): array
     {
-        return [
-            'node' => $this->getNodeName(),
-        ];
+        $info = [};
+        $info['node'] = $this->getNodeName();
+        if (($name = $this->getAttribute('name')) !== null) {
+            $info['name'] = $name;
+        }
+        if (($item = $this->getAttribute('id')) !== null) {
+            $info['item'] = $item;
+        }
+        return $info;
     }
 
     public function debugInfo(array $context = []): bool
@@ -237,9 +213,6 @@ abstract class ElementBase implements ElementInterface, LoggerInterface
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function log($level, $message, array $context = []): void
     {
         $context['path'] = $this->getContextPath();

--- a/src/Model/ElementInterface.php
+++ b/src/Model/ElementInterface.php
@@ -15,6 +15,8 @@ interface ElementInterface
 {
     /**
      * Returns the name of the DOM node of this element.
+     *
+     * @todo remove and leave as a key in collectInfo
      */
     public function getNodeName(): string;
 

--- a/tests/MediaFilesTest.php
+++ b/tests/MediaFilesTest.php
@@ -32,7 +32,7 @@ class MediaFilesTest extends MediaProbeTestCaseBase
         parent::tearDown();
     }
 
-    public function mediaFileProvider()
+    public static function mediaFileProvider()
     {
         $finder = new Finder();
         $finder->files()->in(dirname(__FILE__) . '/media-dumps/image')->name('*.dump.yml');

--- a/tests/ReadWriteTest.php
+++ b/tests/ReadWriteTest.php
@@ -100,7 +100,7 @@ class ReadWriteTest extends MediaProbeTestCaseBase
         }
     }
 
-    public function writeEntryProvider()
+    public static function writeEntryProvider()
     {
         return [
             'Byte Read/Write Tests' => [

--- a/tests/SpecTest.php
+++ b/tests/SpecTest.php
@@ -111,7 +111,7 @@ class SpecTest extends MediaProbeTestCaseBase
     /**
      * Data provider for testGetTagText.
      */
-    public function getTagTextProvider()
+    public static function getTagTextProvider()
     {
         return [
             'IFD0/PlanarConfiguration - value 1' => [

--- a/tests/StubRootBlock.php
+++ b/tests/StubRootBlock.php
@@ -6,4 +6,10 @@ use FileEye\MediaProbe\Model\RootBlockBase;
 
 class StubRootBlock extends RootBlockBase
 {
+    /**
+     * @todo remove, replace by parser
+     */
+    protected function doParseData(DataElement $data): void
+    {
+    }
 }

--- a/tests/StubRootBlock.php
+++ b/tests/StubRootBlock.php
@@ -2,6 +2,7 @@
 
 namespace FileEye\MediaProbe\Test;
 
+use FileEye\MediaProbe\Data\DataElement;
 use FileEye\MediaProbe\Model\RootBlockBase;
 
 class StubRootBlock extends RootBlockBase

--- a/tests/media-dumps/image/broken/canon-eos-650d.jpg.dump.yml
+++ b/tests/media-dumps/image/broken/canon-eos-650d.jpg.dump.yml
@@ -6687,53 +6687,47 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonCustomFunctions2Header:153/index:Exposure:1/tag:ISOSpeedRange:259'
-            message: 'Found 1 data components, expected 3 for item ''ISOSpeedRange'' in ''Exposure'''
+            message: "Found 1 data components, expected 3 for item 'ISOSpeedRange' in 'Exposure'"
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonCameraInfo:13/tag:FirmwareVersion:544/entry'
             message: 'Ascii entry missing final NUL character.'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'Unknown item 25/0x19 in ''Canon'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
+            message: "Unknown item 25/0x19 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:LensModel:149/entry'
             message: 'Ascii entry missing final NUL character.'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
+            message: "Unknown item 2/0x2 in 'CanonMeasuredColor'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
+            message: "Unknown item 3/0x3 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
+            message: "Unknown item 4/0x4 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
+            message: "Unknown item 13/0xD in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
+            message: "Unknown item 14/0xE in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
+            message: "Unknown item 15/0xF in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
+            message: "Unknown item 16/0x10 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'Unknown item 16401/0x4011 in ''Canon'''
+            message: "Unknown item 16401/0x4011 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'Unknown item 16402/0x4012 in ''Canon'''
+            message: "Unknown item 16402/0x4012 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16423'
-            message: 'Unknown item 16423/0x4027 in ''Canon'''
+            message: "Unknown item 16423/0x4027 in 'Canon'"
 gdInfo:
     0: 640
     1: 427
@@ -6744,7 +6738,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon-eos-650d.jpg
-    FileDateTime: 1644612165
+    FileDateTime: 1690031131
     FileSize: 42207
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon_eos_70d_29.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon_eos_70d_29.jpg.dump.yml
@@ -6297,8 +6297,8 @@ elements:
                                                                                     bytesHash: df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119
                                                                                     text: '0'
                                                                 -
-                                                                    node: index
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420'
+                                                                    node: filterInfo
+                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420'
                                                                     class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\FilterInfoIndex
                                                                     valid: true
                                                                     name: CanonFilterInfo
@@ -6307,7 +6307,7 @@ elements:
                                                                     elements:
                                                                         -
                                                                             node: rawData
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/rawData:filterHeader'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/rawData:filterHeader'
                                                                             class: FileEye\MediaProbe\Block\RawData
                                                                             valid: true
                                                                             name: filterHeader
@@ -6315,7 +6315,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: entry
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/rawData:filterHeader/entry'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/rawData:filterHeader/entry'
                                                                                     class: FileEye\MediaProbe\Entry\Core\Undefined
                                                                                     valid: true
                                                                                     format: Undefined
@@ -6324,7 +6324,7 @@ elements:
                                                                                     text: '4 byte(s) of data'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:1'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.0
@@ -6333,7 +6333,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: GrainyBWFilter
@@ -6342,7 +6342,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6351,7 +6351,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:2'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.1
@@ -6360,7 +6360,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: SoftFocusFilter
@@ -6369,7 +6369,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6378,7 +6378,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:3'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.2
@@ -6387,7 +6387,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: ToyCameraFilter
@@ -6396,7 +6396,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6405,7 +6405,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.3
@@ -6414,7 +6414,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilter
@@ -6423,7 +6423,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6432,7 +6432,7 @@ elements:
                                                                                             text: 'Off'
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilterOrientation
@@ -6441,7 +6441,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6450,7 +6450,7 @@ elements:
                                                                                             text: Horizontal
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilterPosition
@@ -6459,7 +6459,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6468,7 +6468,7 @@ elements:
                                                                                             text: '0'
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilterParameter
@@ -6477,7 +6477,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6486,7 +6486,7 @@ elements:
                                                                                             text: '0'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:5'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.4
@@ -6495,7 +6495,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: FisheyeFilter
@@ -6504,7 +6504,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6513,7 +6513,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:6'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.5
@@ -6522,7 +6522,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: PaintingFilter
@@ -6531,7 +6531,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6540,7 +6540,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:7'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.6
@@ -6549,7 +6549,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: WatercolorFilter
@@ -6558,7 +6558,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong

--- a/tests/media-dumps/image/camera/canon_eos_70d_29.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon_eos_70d_29.jpg.dump.yml
@@ -6327,6 +6327,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.0
                                                                             id: '1'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6353,6 +6354,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.1
                                                                             id: '2'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6379,6 +6381,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.2
                                                                             id: '3'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6405,6 +6408,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.3
                                                                             id: '4'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6485,6 +6489,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.4
                                                                             id: '5'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6511,6 +6516,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.5
                                                                             id: '6'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6537,6 +6543,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.6
                                                                             id: '7'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -7234,50 +7241,44 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonCustomFunctions2Header:153/index:AutoFocusDrive:3/tag:AFMicroadjustment:1287'
-            message: 'Found 16 data components, expected 5 for item ''AFMicroadjustment'' in ''AutoFocusDrive'''
+            message: "Found 16 data components, expected 5 for item 'AFMicroadjustment' in 'AutoFocusDrive'"
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'Unknown item 25/0x19 in ''Canon'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
+            message: "Unknown item 25/0x19 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:LensModel:149/entry'
             message: 'Ascii entry missing final NUL character.'
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
+            message: "Unknown item 2/0x2 in 'CanonMeasuredColor'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
+            message: "Unknown item 3/0x3 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
+            message: "Unknown item 4/0x4 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
+            message: "Unknown item 13/0xD in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
+            message: "Unknown item 14/0xE in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
+            message: "Unknown item 15/0xF in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
+            message: "Unknown item 16/0x10 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'Unknown item 16401/0x4011 in ''Canon'''
+            message: "Unknown item 16401/0x4011 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'Unknown item 16402/0x4012 in ''Canon'''
+            message: "Unknown item 16402/0x4012 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16423'
-            message: 'Unknown item 16423/0x4027 in ''Canon'''
+            message: "Unknown item 16423/0x4027 in 'Canon'"
 gdInfo:
     0: 5472
     1: 3648
@@ -7288,7 +7289,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon_eos_70d_29.jpg
-    FileDateTime: 1644612165
+    FileDateTime: 1690031131
     FileSize: 7643244
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon_eos_850d_08.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon_eos_850d_08.jpg.dump.yml
@@ -6389,6 +6389,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.0
                                                                             id: '1'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6415,6 +6416,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.1
                                                                             id: '2'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6441,6 +6443,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.2
                                                                             id: '3'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6467,6 +6470,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.3
                                                                             id: '4'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6547,6 +6551,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.4
                                                                             id: '5'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6573,6 +6578,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.5
                                                                             id: '6'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -6599,6 +6605,7 @@ elements:
                                                                             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
+                                                                            name: CanonFilterInfo.6
                                                                             id: '7'
                                                                             collection: ExifMakerNotes\Canon\Filter
                                                                             elements:
@@ -7416,110 +7423,83 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonCustomFunctions2Header:153/index:Exposure:1/tag:ISOSpeedRange:259'
-            message: 'Found 1 data components, expected 3 for item ''ISOSpeedRange'' in ''Exposure'''
+            message: "Found 1 data components, expected 3 for item 'ISOSpeedRange' in 'Exposure'"
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'Unknown item 25/0x19 in ''Canon'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:17'
-            message: 'Unknown item 17/0x11 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:18'
-            message: 'Unknown item 18/0x12 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:19'
-            message: 'Unknown item 19/0x13 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:20'
-            message: 'Unknown item 20/0x14 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:21'
-            message: 'Unknown item 21/0x15 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:22'
-            message: 'Unknown item 22/0x16 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:23'
-            message: 'Unknown item 23/0x17 in ''CanonAFInfo2'''
+            message: "Unknown item 25/0x19 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:50'
-            message: 'Unknown item 50/0x32 in ''Canon'''
+            message: "Unknown item 50/0x32 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:51'
-            message: 'Unknown item 51/0x33 in ''Canon'''
+            message: "Unknown item 51/0x33 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:61'
-            message: 'Unknown item 61/0x3D in ''Canon'''
+            message: "Unknown item 61/0x3D in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:63'
-            message: 'Unknown item 63/0x3F in ''Canon'''
+            message: "Unknown item 63/0x3F in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:14'
-            message: 'Unknown item 14/0xE in ''CanonProcessing'''
+            message: "Unknown item 14/0xE in 'CanonProcessing'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonProcessing'''
+            message: "Unknown item 15/0xF in 'CanonProcessing'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonProcessing'''
+            message: "Unknown item 16/0x10 in 'CanonProcessing'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonProcessing:160/tag:17'
-            message: 'Unknown item 17/0x11 in ''CanonProcessing'''
+            message: "Unknown item 17/0x11 in 'CanonProcessing'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
+            message: "Unknown item 2/0x2 in 'CanonMeasuredColor'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
+            message: "Unknown item 3/0x3 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
+            message: "Unknown item 4/0x4 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
+            message: "Unknown item 13/0xD in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
+            message: "Unknown item 14/0xE in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
+            message: "Unknown item 15/0xF in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
+            message: "Unknown item 16/0x10 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'Unknown item 16401/0x4011 in ''Canon'''
+            message: "Unknown item 16401/0x4011 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'Unknown item 16402/0x4012 in ''Canon'''
+            message: "Unknown item 16402/0x4012 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16423'
-            message: 'Unknown item 16423/0x4027 in ''Canon'''
+            message: "Unknown item 16423/0x4027 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16428'
-            message: 'Unknown item 16428/0x402C in ''Canon'''
+            message: "Unknown item 16428/0x402C in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16435'
-            message: 'Unknown item 16435/0x4033 in ''Canon'''
+            message: "Unknown item 16435/0x4033 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16441'
-            message: 'Unknown item 16441/0x4039 in ''Canon'''
+            message: "Unknown item 16441/0x4039 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16444'
-            message: 'Unknown item 16444/0x403C in ''Canon'''
+            message: "Unknown item 16444/0x403C in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16445'
-            message: 'Unknown item 16445/0x403D in ''Canon'''
+            message: "Unknown item 16445/0x403D in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16457'
-            message: 'Unknown item 16457/0x4049 in ''Canon'''
+            message: "Unknown item 16457/0x4049 in 'Canon'"
 gdInfo:
     0: 6000
     1: 4000
@@ -7530,7 +7510,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: canon_eos_850d_08.jpg
-    FileDateTime: 1644443574
+    FileDateTime: 1690031131
     FileSize: 8746090
     FileType: 2
     MimeType: image/jpeg

--- a/tests/media-dumps/image/camera/canon_eos_850d_08.jpg.dump.yml
+++ b/tests/media-dumps/image/camera/canon_eos_850d_08.jpg.dump.yml
@@ -6359,8 +6359,8 @@ elements:
                                                                                     bytesHash: df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119
                                                                                     text: Standard
                                                                 -
-                                                                    node: index
-                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420'
+                                                                    node: filterInfo
+                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420'
                                                                     class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\FilterInfoIndex
                                                                     valid: true
                                                                     name: CanonFilterInfo
@@ -6369,7 +6369,7 @@ elements:
                                                                     elements:
                                                                         -
                                                                             node: rawData
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/rawData:filterHeader'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/rawData:filterHeader'
                                                                             class: FileEye\MediaProbe\Block\RawData
                                                                             valid: true
                                                                             name: filterHeader
@@ -6377,7 +6377,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: entry
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/rawData:filterHeader/entry'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/rawData:filterHeader/entry'
                                                                                     class: FileEye\MediaProbe\Entry\Core\Undefined
                                                                                     valid: true
                                                                                     format: Undefined
@@ -6386,7 +6386,7 @@ elements:
                                                                                     text: '4 byte(s) of data'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:1'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.0
@@ -6395,7 +6395,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: GrainyBWFilter
@@ -6404,7 +6404,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:1/tag:GrainyBWFilter:257/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6413,7 +6413,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:2'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.1
@@ -6422,7 +6422,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: SoftFocusFilter
@@ -6431,7 +6431,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:2/tag:SoftFocusFilter:513/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6440,7 +6440,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:3'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.2
@@ -6449,7 +6449,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: ToyCameraFilter
@@ -6458,7 +6458,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:3/tag:ToyCameraFilter:769/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6467,7 +6467,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.3
@@ -6476,7 +6476,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilter
@@ -6485,7 +6485,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilter:1025/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6494,7 +6494,7 @@ elements:
                                                                                             text: 'Off'
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilterOrientation
@@ -6503,7 +6503,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterOrientation:1026/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6512,7 +6512,7 @@ elements:
                                                                                             text: Horizontal
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilterPosition
@@ -6521,7 +6521,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterPosition:1027/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6530,7 +6530,7 @@ elements:
                                                                                             text: '0'
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: MiniatureFilterParameter
@@ -6539,7 +6539,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:4/tag:MiniatureFilterParameter:1028/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6548,7 +6548,7 @@ elements:
                                                                                             text: '0'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:5'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.4
@@ -6557,7 +6557,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: FisheyeFilter
@@ -6566,7 +6566,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:5/tag:FisheyeFilter:1281/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6575,7 +6575,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:6'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.5
@@ -6584,7 +6584,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: PaintingFilter
@@ -6593,7 +6593,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:6/tag:PaintingFilter:1537/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong
@@ -6602,7 +6602,7 @@ elements:
                                                                                             text: 'Off'
                                                                         -
                                                                             node: filter
-                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7'
+                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:7'
                                                                             class: FileEye\MediaProbe\Block\Exif\Vendor\Canon\Filter
                                                                             valid: true
                                                                             name: CanonFilterInfo.6
@@ -6611,7 +6611,7 @@ elements:
                                                                             elements:
                                                                                 -
                                                                                     node: tag
-                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793'
+                                                                                    path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793'
                                                                                     class: FileEye\MediaProbe\Block\Tag
                                                                                     valid: true
                                                                                     name: WatercolorFilter
@@ -6620,7 +6620,7 @@ elements:
                                                                                     elements:
                                                                                         -
                                                                                             node: entry
-                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793/entry'
+                                                                                            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/filterInfo:CanonFilterInfo:16420/filter:7/tag:WatercolorFilter:1793/entry'
                                                                                             class: FileEye\MediaProbe\Entry\Core\SignedLong
                                                                                             valid: true
                                                                                             format: SignedLong

--- a/tests/media-dumps/image/exiftool/Canon1DmkIII.jpg.dump.yml
+++ b/tests/media-dumps/image/exiftool/Canon1DmkIII.jpg.dump.yml
@@ -5821,83 +5821,74 @@ log:
     WARNING:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonFileInfo:147'
-            message: 'Could not access value for item ''FlashExposureLock'' in ''CanonFileInfo'', overflow'
+            message: "Could not access value for item 'FlashExposureLock' in 'CanonFileInfo', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''PerChannelBlackLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'PerChannelBlackLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''NormalWhiteLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'NormalWhiteLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''SpecularWhiteLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'SpecularWhiteLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''LinearityUpperMargin'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'LinearityUpperMargin' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''PerChannelBlackLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'PerChannelBlackLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''NormalWhiteLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'NormalWhiteLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''SpecularWhiteLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'SpecularWhiteLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''LinearityUpperMargin'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'LinearityUpperMargin' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''NormalWhiteLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'NormalWhiteLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''SpecularWhiteLevel'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'SpecularWhiteLevel' in 'CanonColorData', overflow"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/map:CanonColorData:16385'
-            message: 'Could not access value for item ''LinearityUpperMargin'' in ''CanonColorData'', overflow'
+            message: "Could not access value for item 'LinearityUpperMargin' in 'CanonColorData', overflow"
     NOTICE:
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:25'
-            message: 'Unknown item 25/0x19 in ''Canon'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonAFInfo2'''
-        -
-            path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonAFInfo2:38/tag:17'
-            message: 'Unknown item 17/0x11 in ''CanonAFInfo2'''
+            message: "Unknown item 25/0x19 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonMeasuredColor:170/tag:2'
-            message: 'Unknown item 2/0x2 in ''CanonMeasuredColor'''
+            message: "Unknown item 2/0x2 in 'CanonMeasuredColor'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:3'
-            message: 'Unknown item 3/0x3 in ''CanonSensorInfo'''
+            message: "Unknown item 3/0x3 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:4'
-            message: 'Unknown item 4/0x4 in ''CanonSensorInfo'''
+            message: "Unknown item 4/0x4 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:13'
-            message: 'Unknown item 13/0xD in ''CanonSensorInfo'''
+            message: "Unknown item 13/0xD in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:14'
-            message: 'Unknown item 14/0xE in ''CanonSensorInfo'''
+            message: "Unknown item 14/0xE in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:15'
-            message: 'Unknown item 15/0xF in ''CanonSensorInfo'''
+            message: "Unknown item 15/0xF in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/index:CanonSensorInfo:224/tag:16'
-            message: 'Unknown item 16/0x10 in ''CanonSensorInfo'''
+            message: "Unknown item 16/0x10 in 'CanonSensorInfo'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16401'
-            message: 'Unknown item 16401/0x4011 in ''Canon'''
+            message: "Unknown item 16401/0x4011 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16402'
-            message: 'Unknown item 16402/0x4012 in ''Canon'''
+            message: "Unknown item 16402/0x4012 in 'Canon'"
         -
             path: '/media/jpeg/jpegSegment:APP1:225/exif/tiff/ifd:IFD0:0/ifd:ExifIFD:34665/makerNote:Canon:37500/tag:16404'
-            message: 'Unknown item 16404/0x4014 in ''Canon'''
+            message: "Unknown item 16404/0x4014 in 'Canon'"
 gdInfo:
     0: 8
     1: 8
@@ -5908,7 +5899,7 @@ gdInfo:
     mime: image/jpeg
 exifReadData:
     FileName: Canon1DmkIII.jpg
-    FileDateTime: 1644443574
+    FileDateTime: 1690031131
     FileSize: 8337
     FileType: 2
     MimeType: image/jpeg


### PR DESCRIPTION
- [x] move debug to dpParseData
- [ ] map #entries
- [ ] map tags @0/0x0
- [ ] index tags @0/0x0
- [ ] move errors to after debuginfo
- [ ] index:CanonAFInfo2 misses debug of entries
- [ ] index:CanonCustomFunctions2Header to dumper
- [x] filter parameters
- [x] duplicated index debug info
- [x] filter results as index: on top element

